### PR TITLE
change: various improvements to auto-merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Changed
 
+- Reduced the number of automatic checks that are performed every time a PR gets updated. ([#217](https://github.com/eclipse-csi/otterdog/issues/217))
+- Support auto-merge also for project leads and admins. ([#216](https://github.com/eclipse-csi/otterdog/issues/216))
+- Do not enable auto-merge for PRs that also touch files other than the configuration. ([#220](https://github.com/eclipse-csi/otterdog/issues/220))
 - Use scoped commands for interaction via pull requests. ([#211](https://github.com/eclipse-csi/otterdog/issues/211))
 
 ### Fixed

--- a/otterdog/providers/github/rest/commit_client.py
+++ b/otterdog/providers/github/rest/commit_client.py
@@ -7,7 +7,9 @@
 #  *******************************************************************************
 
 import json
+from typing import Any
 
+from otterdog.providers.github.exception import GitHubException
 from otterdog.utils import print_debug
 
 from . import RestApi, RestClient
@@ -16,6 +18,15 @@ from . import RestApi, RestClient
 class CommitClient(RestClient):
     def __init__(self, rest_api: RestApi):
         super().__init__(rest_api)
+
+    async def get_commit_statuses(self, org_id: str, repo_name: str, ref: str) -> list[dict[str, Any]]:
+        print_debug(f"getting commit statuses for ref '{ref}' from repo '{org_id}/{repo_name}'")
+
+        try:
+            return await self.requester.request_paged_json("GET", f"/repos/{org_id}/{repo_name}/commits/{ref}/statuses")
+        except GitHubException as ex:
+            tb = ex.__traceback__
+            raise RuntimeError(f"failed retrieving commit statuses:\n{ex}").with_traceback(tb)
 
     async def create_commit_status(
         self,

--- a/otterdog/providers/github/rest/pull_request_client.py
+++ b/otterdog/providers/github/rest/pull_request_client.py
@@ -43,6 +43,17 @@ class PullRequestClient(RestClient):
             tb = ex.__traceback__
             raise RuntimeError(f"failed retrieving pull requests:\n{ex}").with_traceback(tb)
 
+    async def get_commits(self, org_id: str, repo_name: str, pull_request_number: str) -> list[dict[str, Any]]:
+        print_debug(f"getting commits for pull request #{pull_request_number} from repo '{org_id}/{repo_name}'")
+
+        try:
+            return await self.requester.request_paged_json(
+                "GET", f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}/commits"
+            )
+        except GitHubException as ex:
+            tb = ex.__traceback__
+            raise RuntimeError(f"failed retrieving pull request commits:\n{ex}").with_traceback(tb)
+
     async def get_reviews(self, org_id: str, repo_name: str, pull_request_number: str) -> list[dict[str, Any]]:
         print_debug(f"getting reviews for pull request #{pull_request_number} from repo '{org_id}/{repo_name}'")
 
@@ -53,6 +64,17 @@ class PullRequestClient(RestClient):
         except GitHubException as ex:
             tb = ex.__traceback__
             raise RuntimeError(f"failed retrieving pull request reviews:\n{ex}").with_traceback(tb)
+
+    async def get_files(self, org_id: str, repo_name: str, pull_request_number: str) -> list[dict[str, Any]]:
+        print_debug(f"getting files for pull request #{pull_request_number} from repo '{org_id}/{repo_name}'")
+
+        try:
+            return await self.requester.request_paged_json(
+                "GET", f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}/files"
+            )
+        except GitHubException as ex:
+            tb = ex.__traceback__
+            raise RuntimeError(f"failed retrieving pull request files:\n{ex}").with_traceback(tb)
 
     async def merge(
         self,

--- a/otterdog/webapp/api/routes.py
+++ b/otterdog/webapp/api/routes.py
@@ -58,7 +58,7 @@ async def tasks():
 @blueprint.route("/pullrequests/merged")
 async def merged_pullrequests():
     paged_pull_requests, count = await get_merged_pull_requests_paged(request.args.to_dict())
-    result = {"data": list(map(lambda x: x.model_dump(exclude={"id"}), paged_pull_requests)), "itemsCount": count}
+    result = {"data": list(map(lambda x: x.model_dump(), paged_pull_requests)), "itemsCount": count}
     return jsonify(result)
 
 

--- a/otterdog/webapp/tasks/apply_changes.py
+++ b/otterdog/webapp/tasks/apply_changes.py
@@ -104,6 +104,13 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
             )
             return False
 
+        if self._pr_model.valid is not True:
+            self.logger.error(
+                f"trying to apply changes for invalid pull request #{self.pull_request_number} "
+                f"of org '{self.org_id}', skipping"
+            )
+            return False
+
         if self.author is not None:
             rest_api = await self.rest_api
             admin_teams = get_admin_teams()
@@ -165,7 +172,7 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
             )
 
             output = StringIO()
-            printer = IndentingPrinter(output, log_level=LogLevel.ERROR)
+            printer = IndentingPrinter(output, log_level=LogLevel.WARN)
 
             # let's create an apply operation that forces processing but does not update
             # any web UI settings and resources using credentials

--- a/otterdog/webapp/tasks/auto_merge_comment.py
+++ b/otterdog/webapp/tasks/auto_merge_comment.py
@@ -37,22 +37,21 @@ class AutoMergeCommentTask(InstallationBasedTask, Task[None]):
             self.repo_name,
         )
 
-        rest_api = await self.rest_api
-        comment = await render_template("comment/auto_merge_comment.txt")
-
-        await self.minimize_outdated_comments(
+        if not self.comment_with_header_exists(
             self.org_id,
             self.repo_name,
             self.pull_request_number,
             "<!-- Otterdog Comment: automerge -->",
-        )
+        ):
+            comment = await render_template("comment/auto_merge_comment.txt")
 
-        await rest_api.issue.create_comment(
-            self.org_id,
-            self.repo_name,
-            str(self.pull_request_number),
-            comment,
-        )
+            rest_api = await self.rest_api
+            await rest_api.issue.create_comment(
+                self.org_id,
+                self.repo_name,
+                str(self.pull_request_number),
+                comment,
+            )
 
     def __repr__(self) -> str:
         return f"AutoMergeCommentTask(repo='{self.org_id}/{self.repo_name}', pull_request=#{self.pull_request_number})"

--- a/otterdog/webapp/templates/comment/applied_changes_comment.txt
+++ b/otterdog/webapp/templates/comment/applied_changes_comment.txt
@@ -11,7 +11,7 @@ The following changes have been successfully applied:
 ### Note
 
 The pull request was only partially applied as it requires some access to secrets or the Web UI,
-please apply the remaining changes manually and confirm with replying with `/done`.
+please apply the remaining changes manually and confirm with replying with `/otterdog done`.
 
 {% for admin_team in admin_teams %}
 cc @{{ admin_team }}

--- a/otterdog/webapp/templates/comment/wrong_user_merge_comment.txt
+++ b/otterdog/webapp/templates/comment/wrong_user_merge_comment.txt
@@ -1,2 +1,2 @@
 This is your friendly self-service bot.
-Only the author of the pull request is allowed to auto-merge it.
+Only the author of the pull request, a project-lead or a member of the admin teams is allowed to auto-merge it.

--- a/otterdog/webapp/templates/home/pullrequests.html
+++ b/otterdog/webapp/templates/home/pullrequests.html
@@ -66,10 +66,11 @@
                   </thead>
                   <tbody>
                     {% for pr in open_pull_requests %}
+                    {% set id = pr.id %}
                     <tr class="{{ 'table-secondary' if pr.draft == True else ''}}">
-                      <td><a href="https://github.com/{{ pr.org_id }}">{{ pr.org_id }}</a></td>
-                      <td><a href="https://github.com/{{ pr.org_id }}/{{ pr.repo_name }}">{{ pr.repo_name }}</a></td>
-                      <td><a href="https://github.com/{{ pr.org_id }}/{{ pr.repo_name }}/pull/{{ pr.pull_request }}">#{{ pr.pull_request }}</a></td>
+                      <td><a href="https://github.com/{{ id.org_id }}">{{ id.org_id }}</a></td>
+                      <td><a href="https://github.com/{{ id.org_id }}/{{ id.repo_name }}">{{ id.repo_name }}</a></td>
+                      <td><a href="https://github.com/{{ id.org_id }}/{{ id.repo_name }}/pull/{{ id.pull_request }}">#{{ id.pull_request }}</a></td>
                       <td>{{ pr.created_at }}</td>
                       <td>{{ pr.status }}</td>
                       <td class="{{ 'text-primary' if pr.draft == True else '' }}">{{ pr.draft }}</td>
@@ -131,18 +132,11 @@
   <!-- page script -->
   <script>
     $(function () {
-      $('#open-pull-requests').DataTable({
-        "order": [[3, 'desc']],
-        "autoWidth": false,
-        "responsive": true,
-      });
-
       $('#merged-pull-requests').DataTable({
         "order": [[3, 'desc']],
         "autoWidth": false,
         "responsive": true,
       });
-
     });
 
     $(function () {
@@ -175,17 +169,17 @@
           },
 
           fields: [
-              { name: "org_id", title: "GitHub Organization", type: "text", width: 70,
+              { name: "id.org_id", title: "GitHub Organization", type: "text", width: 70,
                 itemTemplate: function(value, item) {
                   return "<a href='https://github.com/" + value + "'>" + value + "</a>";
                 }
               },
-              { name: "repo_name", title: "Repo name", type: "text", width: 50,
+              { name: "id.repo_name", title: "Repo name", type: "text", width: 50,
                 itemTemplate: function(value, item) {
                   return "<a href='https://github.com/" + item.org_id + "/" + value + "'>" + value + "</a>";
                 }
               },
-              { name: "pull_request", title: "Pull Request", type: "number", align: "center", width: 50,
+              { name: "id.pull_request", title: "Pull Request", type: "number", align: "center", width: 50,
                 itemTemplate: function(value, item) {
                   if (value > 0) {
                     return "<a href='https://github.com/" + item.org_id + "/" + item.repo_name + "/pull/" + value + "'>#" + value + "</a>";

--- a/otterdog/webapp/templates/home/pullrequests.html
+++ b/otterdog/webapp/templates/home/pullrequests.html
@@ -176,13 +176,13 @@
               },
               { name: "id.repo_name", title: "Repo name", type: "text", width: 50,
                 itemTemplate: function(value, item) {
-                  return "<a href='https://github.com/" + item.org_id + "/" + value + "'>" + value + "</a>";
+                  return "<a href='https://github.com/" + item.id.org_id + "/" + value + "'>" + value + "</a>";
                 }
               },
               { name: "id.pull_request", title: "Pull Request", type: "number", align: "center", width: 50,
                 itemTemplate: function(value, item) {
                   if (value > 0) {
-                    return "<a href='https://github.com/" + item.org_id + "/" + item.repo_name + "/pull/" + value + "'>#" + value + "</a>";
+                    return "<a href='https://github.com/" + item.id.org_id + "/" + item.id.repo_name + "/pull/" + value + "'>#" + value + "</a>";
                   } else {
                     return "N/A";
                   }

--- a/otterdog/webapp/webhook/__init__.py
+++ b/otterdog/webapp/webhook/__init__.py
@@ -73,14 +73,23 @@ async def on_pull_request_received(data):
     if not await targets_config_repo(event.repository.name, event.installation.id):
         return success()
 
-    current_app.add_background_task(
-        UpdatePullRequestTask(
-            event.installation.id,
-            event.organization.login,
-            event.repository.name,
-            event.pull_request,
+    if event.action in [
+        "opened",
+        "closed",
+        "ready_for_review",
+        "converted_to_draft",
+        "ready_for_review",
+        "reopened",
+        "synchronize",
+    ]:
+        current_app.add_background_task(
+            UpdatePullRequestTask(
+                event.installation.id,
+                event.organization.login,
+                event.repository.name,
+                event.pull_request,
+            )
         )
-    )
 
     if event.action in ["opened", "ready_for_review"] and event.pull_request.draft is False:
         current_app.add_background_task(


### PR DESCRIPTION
This fixes #220, #217, #216.

- allow project leads to auto-merge eligible PRs from other authors
- reduce automatic tasks that get executed every time a PRs gets updated
- disable auto-merge if unrelated changes are detected