### PR TITLE
feat: add new operation local-apply and use it for the ApplyChangesTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ### Added
 
+- Added operation `local-apply` to apply change based on two local configurations. ([#257](https://github.com/eclipse-csi/otterdog/issues/257))
 - Added policy `macos_large_runners` to control whether MacOS large runners are permitted to use in an organization. ([#251](https://github.com/eclipse-csi/otterdog/issues/251))
 - Added operation `install-app` to install a GitHub app for an organization. ([#250](https://github.com/eclipse-csi/otterdog/issues/250))
 - Added option `--no-diff` and `--force` to the `push-config` operation to disable showing diffs and interactive approvals. ([#246](https://github.com/eclipse-csi/otterdog/issues/246))
 
 ### Changed
 
+- Changed `ApplyChangesTask` to use a `local-apply` operation rather than an `apply` operation. ([#257](https://github.com/eclipse-csi/otterdog/issues/257))
+- Changed operation `fetch-config` to include 2 additional parameters `suffix` and `ref` to fetch a config from a specific git reference.
 - Changed operation `push-config` to always show a diff of the local changes compared to the current remote configuration prior to execution. ([#246](https://github.com/eclipse-csi/otterdog/issues/246))
 
 ### Fixed

--- a/otterdog/operations/local_apply.py
+++ b/otterdog/operations/local_apply.py
@@ -1,0 +1,66 @@
+#  *******************************************************************************
+#  Copyright (c) 2023-2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+import aiofiles.ospath
+
+from otterdog.jsonnet import JsonnetConfig
+from otterdog.models.github_organization import GitHubOrganization
+
+from .apply import ApplyOperation
+
+
+class LocalApplyOperation(ApplyOperation):
+    def __init__(
+        self,
+        suffix: str,
+        force_processing: bool,
+        no_web_ui: bool,
+        update_webhooks: bool,
+        update_secrets: bool,
+        update_filter: str,
+        delete_resources: bool,
+        resolve_secrets: bool = True,
+        include_resources_with_secrets: bool = True,
+    ) -> None:
+        super().__init__(
+            force_processing=force_processing,
+            no_web_ui=no_web_ui,
+            update_webhooks=update_webhooks,
+            update_secrets=update_secrets,
+            update_filter=update_filter,
+            delete_resources=delete_resources,
+            resolve_secrets=resolve_secrets,
+            include_resources_with_secrets=include_resources_with_secrets,
+        )
+
+        self._suffix = suffix
+        self._other_org: GitHubOrganization | None = None
+
+    @property
+    def suffix(self) -> str:
+        return self._suffix
+
+    @property
+    def other_org(self) -> GitHubOrganization:
+        assert self._other_org is not None
+        return self._other_org
+
+    def pre_execute(self) -> None:
+        self.printer.println("Applying local changes:")
+        self.print_legend()
+
+    def verbose_output(self):
+        return False
+
+    async def load_current_org(self, github_id: str, jsonnet_config: JsonnetConfig) -> GitHubOrganization:
+        other_org_file_name = jsonnet_config.org_config_file + self.suffix
+
+        if not await aiofiles.ospath.exists(other_org_file_name):
+            raise RuntimeError(f"configuration file '{other_org_file_name}' does not exist")
+
+        return GitHubOrganization.load_from_file(github_id, other_org_file_name, self.config)

--- a/otterdog/providers/github/rest/commit_client.py
+++ b/otterdog/providers/github/rest/commit_client.py
@@ -19,6 +19,15 @@ class CommitClient(RestClient):
     def __init__(self, rest_api: RestApi):
         super().__init__(rest_api)
 
+    async def get_commit(self, org_id: str, repo_name: str, ref: str) -> dict[str, Any]:
+        print_debug(f"getting commit for ref '{ref}' from repo '{org_id}/{repo_name}'")
+
+        try:
+            return await self.requester.request_json("GET", f"/repos/{org_id}/{repo_name}/commits/{ref}")
+        except GitHubException as ex:
+            tb = ex.__traceback__
+            raise RuntimeError(f"failed retrieving commit:\n{ex}").with_traceback(tb)
+
     async def get_commit_statuses(self, org_id: str, repo_name: str, ref: str) -> list[dict[str, Any]]:
         print_debug(f"getting commit statuses for ref '{ref}' from repo '{org_id}/{repo_name}'")
 

--- a/otterdog/webapp/db/service.py
+++ b/otterdog/webapp/db/service.py
@@ -336,10 +336,10 @@ async def fail_task(task: TaskModel, exception: Exception) -> None:
     await mongo.odm.save(task)
 
 
-async def get_latest_sync_or_apply_task_for_organization(org_id: str, repo_name: str) -> TaskModel | None:
+async def get_latest_sync_task_for_organization(org_id: str, repo_name: str) -> TaskModel | None:
     tasks = await mongo.odm.find(
         TaskModel,
-        query.or_(TaskModel.type == "CheckConfigurationInSyncTask", TaskModel.type == "ApplyChangesTask"),
+        TaskModel.type == "CheckConfigurationInSyncTask",
         TaskModel.status != TaskStatus.CREATED,
         TaskModel.org_id == org_id,
         TaskModel.repo_name == repo_name,

--- a/otterdog/webapp/tasks/check_sync.py
+++ b/otterdog/webapp/tasks/check_sync.py
@@ -20,7 +20,7 @@ from otterdog.operations.plan import PlanOperation
 from otterdog.utils import IndentingPrinter, LogLevel
 from otterdog.webapp.db.models import TaskModel
 from otterdog.webapp.db.service import (
-    get_latest_sync_or_apply_task_for_organization,
+    get_latest_sync_task_for_organization,
     update_or_create_pull_request,
 )
 from otterdog.webapp.tasks import InstallationBasedTask, Task
@@ -120,7 +120,7 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
                         await self._update_final_status(commit_status[0]["state"] == "success")
                         return False
 
-        latest_sync_or_apply_task = await get_latest_sync_or_apply_task_for_organization(self.org_id, self.repo_name)
+        latest_sync_or_apply_task = await get_latest_sync_task_for_organization(self.org_id, self.repo_name)
         # to avoid secondary rate limit failures, backoff at least 1 min before running another sync task
         if latest_sync_or_apply_task is not None:
             await backoff_if_needed(latest_sync_or_apply_task.created_at, timedelta(minutes=1))


### PR DESCRIPTION
This fixes #257 .

Adds a new operation local-apply to apply all changes between two local configurations.
That is used in the ApplyChangesTask of the GitHub App to apply approved changes from a PR. The task will fetch the latest config that has been modified by the PR and the previous one, run the local-apply operation with these 2 configs.

That should avoid getting the current live configuration from GitHub, reducing the number of API calls and speeding up the applying. It is safe to do so as the check-sync task will ensure that the configuration is in sync.