### PR TITLE
update: Mark go as a required bin for otterdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It is actively developed by the Eclipse Foundation and used to manage its numero
 To install and use the cli part of otterdog you have to install the following:
 
 * git (mandatory): install using `apt install git`
+* go (mandatory): install using `apt install golang-go`
 * otterdog (mandatory): install using `pipx install otterdog`
 * bitwarden cli tool (optional): install using `snap install bw`
 * pass cli tool (optional): install using `apt install pass`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It is actively developed by the Eclipse Foundation and used to manage its numero
 To install and use the cli part of otterdog you have to install the following:
 
 * git (mandatory): install using `apt install git`
-* go (mandatory): install using `apt install golang-go`
+* go (mandatory): install using `apt install golang-1.23` or `snap install go`
 * otterdog (mandatory): install using `pipx install otterdog`
 * bitwarden cli tool (optional): install using `snap install bw`
 * pass cli tool (optional): install using `apt install pass`

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The documentation is available at [otterdog.readthedocs.io](https://otterdog.rea
 
 * python3.10+ (mandatory): e.g. install using `apt install python3` or `pyenv`
 * git (mandatory): install using `apt install git`
+* go (mandatory): install using `apt install golang-1.23` or `snap install go`
 * poetry (mandatory): install using `curl -sSL https://install.python-poetry.org | python3 -` or `pipx install poetry`
 * bitwarden cli tool (optional): install using `snap install bw`
 * pass cli tool (optional): install using `apt install pass`


### PR DESCRIPTION
Required by one of the dep packages in otterdog (gojsonnet). W/o go installed the call to `make init` will fail due to an inability to build the wheel for gojsonnet, blocking the script.