### PR TITLE
Revert "chore(deps): bump pypa/gh-action-pypi-publish from 1.11.0 to 1.12.2"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,7 +199,7 @@ jobs:
           path: "dist/"
 
       - name: "Publish dists to PyPI"
-        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
+        uses: pypa/gh-action-pypi-publish@fb13cb306901256ace3dab689990e13a5550ffaa # v1.11.0
         with:
           attestations: true
 
@@ -220,7 +220,7 @@ jobs:
           path: "dist/"
 
       - name: "Publish dists to Test PyPI"
-        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
+        uses: pypa/gh-action-pypi-publish@fb13cb306901256ace3dab689990e13a5550ffaa # v1.11.0
         with:
           repository-url: https://test.pypi.org/legacy/
           attestations: true


### PR DESCRIPTION
Reverts eclipse-csi/otterdog#316