### PR TITLE
Add support for tox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - '3.13'
           - '3.12'
           - '3.11'
     steps:

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ The documentation is available at [otterdog.readthedocs.io](https://otterdog.rea
 
 ### System requirements:
 
-* python3.11+ (mandatory): e.g. install using `apt install python3` or use `pyenv`
+* python3.11+ (mandatory): e.g. install using `apt install python3` or use `pyenv install 3.12`
 * git (mandatory): install using `apt install git`
 * poetry (mandatory): install using `pipx install poetry`
+* dynamic versioning plugin (mandatory): install using `pipx inject poetry "poetry-dynamic-versioning[plugin]"`
 * bitwarden cli tool (optional): install using `snap install bw`
 * pass cli tool (optional): install using `apt install pass`
 
@@ -58,6 +59,8 @@ The documentation is available at [otterdog.readthedocs.io](https://otterdog.rea
 ```console
 $ make init
 ```
+
+Running `make init` will also install `poetry` and the `dynamic versioning plugin` if it is not installed yet.
 
 * Testing build
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -326,6 +326,17 @@ files = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "5.5.0"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"},
+    {file = "cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -424,6 +435,17 @@ python-versions = ">=3.8"
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
 ]
 
 [[package]]
@@ -2157,6 +2179,24 @@ docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
+name = "pyproject-api"
+version = "1.8.0"
+description = "API to interact with the python pyproject.toml based projects"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228"},
+    {file = "pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496"},
+]
+
+[package.dependencies]
+packaging = ">=24.1"
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "pytest (>=8.3.3)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
+
+[[package]]
 name = "pytest"
 version = "8.3.3"
 description = "pytest: simple powerful testing with Python"
@@ -2763,6 +2803,31 @@ anyio = ">=3.4.0,<5"
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
 
 [[package]]
+name = "tox"
+version = "4.23.2"
+description = "tox is a generic virtualenv management and test command line tool"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38"},
+    {file = "tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c"},
+]
+
+[package.dependencies]
+cachetools = ">=5.5"
+chardet = ">=5.2"
+colorama = ">=0.4.6"
+filelock = ">=3.16.1"
+packaging = ">=24.1"
+platformdirs = ">=4.3.6"
+pluggy = ">=1.5"
+pyproject-api = ">=1.8"
+virtualenv = ">=20.26.6"
+
+[package.extras]
+test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.3)", "pytest-mock (>=3.14)"]
+
+[[package]]
 name = "types-aiofiles"
 version = "24.1.0.20240626"
 description = "Typing stubs for aiofiles"
@@ -3123,4 +3188,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11, <4.0"
-content-hash = "75852fe5027e0407baae40fd9fad1aa9f0bd3c3f9717e5dad96d3108b6853876"
+content-hash = "47a62640ef10f53e2a00ae34023c581fa98f994135300063f81a52fba7f71ad2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers   = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
@@ -88,6 +89,7 @@ mypy       = "^1.8"
 pre-commit = "^4.0"
 
 [tool.poetry.group.test.dependencies]
+tox            = ">4.22"
 pytest         = "^8.0"
 pytest-asyncio = "^0.24"
 parameterized  = "^0.9"
@@ -143,6 +145,8 @@ log_cli_level       = "INFO"
 log_cli_format      = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
+asyncio_default_fixture_loop_scope="function"
+
 [tool.mypy]
 python_version = "3.11"
 exclude        = ["scripts", "docs", "tests"]
@@ -181,3 +185,14 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "**/db/models.py" = ["UP007", "TCH003"] # new optional spec is not yet supported by odmantic
 "**/webhook/github_models.py" = ["TCH003"]
+
+[tool.tox]
+requires = ["tox>=4.22"]
+env_list = ["3.11", "3.12", "3.13"]
+
+[tool.tox.env_run_base]
+description = "Run tests under {base_python}"
+skip_install = true
+allowlist_externals = ["poetry"]
+commands_pre = [["poetry", "install", "--without", "dev,typing,docs"]]
+commands = [["poetry", "run", "pytest", "tests/", "--import-mode", "importlib"]]


### PR DESCRIPTION
This PR adds support for tox to run tests for different python versions locally.

It also reinstates python 3.13 as supported version now that rjsonnet is used.