### PR TITLE
feat: add post-add-objects hook for apply operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added support for a `post-add-objects` hook in the default configuration that gets executed after resources have been added. ([#318](https://github.com/eclipse-csi/otterdog/issues/318))
 - Added new blueprint `pin_workflow` to used GitHub actions in workflows.
 - Added a new operation `list-advisories` to list GitHub Security Advisories for organizations.
 

--- a/otterdog/webapp/tasks/apply_changes.py
+++ b/otterdog/webapp/tasks/apply_changes.py
@@ -179,7 +179,7 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
             )
 
             output = StringIO()
-            printer = IndentingPrinter(output, log_level=LogLevel.WARN)
+            printer = IndentingPrinter(output, log_level=LogLevel.WARN, output_for_github=True)
 
             # let's create an apply operation that forces processing but does not update
             # any web UI settings and resources using credentials

--- a/otterdog/webapp/tasks/check_sync.py
+++ b/otterdog/webapp/tasks/check_sync.py
@@ -155,7 +155,7 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
             )
 
             output = StringIO()
-            printer = IndentingPrinter(output, log_level=LogLevel.ERROR)
+            printer = IndentingPrinter(output, log_level=LogLevel.ERROR, output_for_github=True)
             operation = PlanOperation(True, "*", False, False, "")
             # set concurrency to 20 to avoid hitting secondary rate limits with installation tokens
             operation.concurrency = 20

--- a/otterdog/webapp/tasks/validate_pull_request.py
+++ b/otterdog/webapp/tasks/validate_pull_request.py
@@ -147,7 +147,7 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
                 validation_result.validation_success = True
             else:
                 output = StringIO()
-                printer = IndentingPrinter(output, log_level=self.log_level)
+                printer = IndentingPrinter(output, log_level=self.log_level, output_for_github=True)
                 operation = LocalPlanOperation("-BASE", "*", False, False, "")
 
                 def callback(org_id: str, diff_status: DiffStatus, patches: list[LivePatch]):


### PR DESCRIPTION
This fixes #318 .

Adds a `post-add-objects` hook for the default config.

Example output:

``` diff
! Warning: The following GitHub repos have been created:
!      - https://github.com/OtterdogTest/test-repo8
!    Committers will gain access to it once the sync script runs (~2h).
```