### PR TITLE
fix: updating or deleting webhooks with wildcards via the local-apply operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Fixed updating or deleting webhooks with wildcard patterns via the `local-apply` operations. ([#325](https://github.com/eclipse-csi/otterdog/issues/325))
 - Fixed importing of `rulesets` due to missing handling of embedded model object `required_status_checks`.
 - Changing setting `squash_merge_commit_message` also requires that setting `squash_merge_commit_title` is present in the payload sent to GitHub.
 

--- a/otterdog/providers/github/rest/org_client.py
+++ b/otterdog/providers/github/rest/org_client.py
@@ -159,8 +159,12 @@ class OrgClient(RestClient):
 
         webhooks = await self.get_webhooks(org_id)
 
+        has_wildcard_url = url.endswith("*")
+        stripped_url = url.rstrip("*")
+
         for webhook in webhooks:
-            if webhook["config"]["url"] == url:
+            webhook_url = webhook["config"]["url"]
+            if has_wildcard_url is True and webhook_url.startswith(stripped_url) or webhook_url == url:
                 return webhook["id"]
 
         raise RuntimeError(f"failed to find org webhook with url '{url}'")

--- a/otterdog/providers/github/rest/repo_client.py
+++ b/otterdog/providers/github/rest/repo_client.py
@@ -268,8 +268,12 @@ class RepoClient(RestClient):
 
         webhooks = await self.get_webhooks(org_id, repo_name)
 
+        has_wildcard_url = url.endswith("*")
+        stripped_url = url.rstrip("*")
+
         for webhook in webhooks:
-            if webhook["config"]["url"] == url:
+            webhook_url = webhook["config"]["url"]
+            if has_wildcard_url is True and webhook_url.startswith(stripped_url) or webhook_url == url:
                 return webhook["id"]
 
         raise RuntimeError(f"failed to find repo webhook with url '{url}'")


### PR DESCRIPTION
This fixes #325 .