### PR TITLE
feat: add append configuration blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added new blueprint `append_configuration` to append configuration snippets depending on certain conditions.
 - Added support for organization rulesets. ([#158](https://github.com/eclipse-csi/otterdog/issues/158))
 - Added support for templates in `required-file` blueprints. ([#322](https://github.com/eclipse-csi/otterdog/issues/322))
 - Added support for a `post-add-objects` hook in the default configuration that gets executed after resources have been added. ([#318](https://github.com/eclipse-csi/otterdog/issues/318))

--- a/docs/reference/blueprints/append-configuration.md
+++ b/docs/reference/blueprints/append-configuration.md
@@ -1,0 +1,53 @@
+# Append Configuration
+
+This blueprint type will append a configuration snippet to the configuration of an organization
+depending on a condition that is evaluated against the current configuration.
+
+## Configuration
+
+- `type` - `append_configuration`
+
+### Settings
+
+| Setting   | Necessity | Value type | Description                                                                                      |
+|-----------|-----------|------------|--------------------------------------------------------------------------------------------------|
+| condition | mandatory | string     | a [JSONata](https://jsonata.org/) expression that is evaluated against the current configuration |
+| content   | mandatory | string     | the configuration snippet to add if the `condition` evaluates to `true`                          |
+
+### References
+
+- [JSONata playground](https://try.jsonata.org/)
+- [JSONata documentation](https://docs.jsonata.org/overview.html)
+
+## Example
+
+The following example adds an [Organization Ruleset](../organization/ruleset.md) to the configuration to prevent force-pushes
+on the default branch of any repository if one does not exist yet:
+
+``` yaml
+id: prevent-force-pushes
+name: Prevents force-pushes for the default branch
+type: append_configuration
+config:
+  condition: >-
+    $count($.rulesets[allows_force_pushes = false and
+    "~DEFAULT_BRANCH" in include_refs and
+    "~ALL" in include_repo_names and target = "branch"]) = 0
+  content: |-
+    {
+      # snippet added due to '{{blueprint_url}}'
+      rulesets+: [
+        orgs.newOrgRuleset('{{blueprint_id}}') {
+          allows_creations: true,
+          include_repo_names: [
+            "~ALL"
+          ],
+          include_refs: [
+            "~DEFAULT_BRANCH"
+          ],
+          required_pull_request: null,
+          required_status_checks: null,
+        },
+      ],
+    }
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,8 @@ nav:
         - reference/blueprints/index.md
         - Required File: reference/blueprints/required-file.md
         - Pin Workflow: reference/blueprints/pin-workflow.md
+        - Append Configuration: reference/blueprints/append-configuration.md
+
     - CLI Operations:
         - reference/operations/index.md
         - Apply: reference/operations/apply.md

--- a/otterdog/webapp/blueprints/__init__.py
+++ b/otterdog/webapp/blueprints/__init__.py
@@ -22,6 +22,7 @@ from otterdog.models.github_organization import GitHubOrganization
 if TYPE_CHECKING:
     from otterdog.models.repository import Repository
     from otterdog.webapp.db.models import BlueprintModel, ConfigurationModel
+    from otterdog.webapp.webhook.github_models import Commit
 
 BLUEPRINT_PATH = "otterdog/blueprints"
 
@@ -87,6 +88,9 @@ class Blueprint(ABC, BaseModel):
                 # if a recheck is needed, cleanup status of non-matching repos if they exist
                 if recheck:
                     await cleanup_blueprint_status_of_repo(github_id, repo.name, self.id)
+
+    @abstractmethod
+    def should_reevaluate(self, commits: list[Commit]) -> bool: ...
 
     @abstractmethod
     async def evaluate_repo(

--- a/otterdog/webapp/blueprints/__init__.py
+++ b/otterdog/webapp/blueprints/__init__.py
@@ -29,6 +29,7 @@ BLUEPRINT_PATH = "otterdog/blueprints"
 class BlueprintType(str, Enum):
     REQUIRED_FILE = "required_file"
     PIN_WORKFLOW = "pin_workflow"
+    APPEND_CONFIGURATION = "append_configuration"
 
 
 class Blueprint(ABC, BaseModel):
@@ -49,6 +50,10 @@ class Blueprint(ABC, BaseModel):
     def config(self) -> dict[str, Any]:
         return self.model_dump(exclude={"id", "path", "name", "description"})
 
+    async def _get_repositories(self, config_model: ConfigurationModel) -> list[Repository]:
+        github_organization = GitHubOrganization.from_model_data(config_model.config)
+        return github_organization.repositories
+
     @abstractmethod
     def _matches(self, repo: Repository) -> bool: ...
 
@@ -60,12 +65,11 @@ class Blueprint(ABC, BaseModel):
             get_configuration_by_github_id,
         )
 
-        config_data = await get_configuration_by_github_id(github_id)
-        if config_data is None:
+        config_model = await get_configuration_by_github_id(github_id)
+        if config_model is None:
             return
 
-        github_organization = GitHubOrganization.from_model_data(config_data.config)
-        for repo in github_organization.repositories:
+        for repo in await self._get_repositories(config_model):
             if repo.archived is False and self._matches(repo):
                 # if no recheck is requested, only check the repo if it was not checked before
                 if recheck is False:
@@ -78,7 +82,7 @@ class Blueprint(ABC, BaseModel):
                         continue
 
                 self.logger.debug(f"checking blueprint with id '{self.id}' in repo '{github_id}/{repo.name}'")
-                await self.evaluate_repo(installation_id, github_id, repo.name, config_data)
+                await self.evaluate_repo(installation_id, github_id, repo.name, config_model)
             else:
                 # if a recheck is needed, cleanup status of non-matching repos if they exist
                 if recheck:
@@ -136,6 +140,11 @@ def create_blueprint(
             from otterdog.webapp.blueprints.pin_workflow import PinWorkflowBlueprint
 
             return PinWorkflowBlueprint.model_validate(data)
+
+        case BlueprintType.APPEND_CONFIGURATION:
+            from otterdog.webapp.blueprints.append_configuration import AppendConfigurationBlueprint
+
+            return AppendConfigurationBlueprint.model_validate(data)
 
         case _:
             raise RuntimeError(f"unknown blueprint type '{blueprint_type}'")

--- a/otterdog/webapp/blueprints/append_configuration.py
+++ b/otterdog/webapp/blueprints/append_configuration.py
@@ -1,0 +1,65 @@
+#  *******************************************************************************
+#  Copyright (c) 2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from quart import current_app
+
+from otterdog.models.github_organization import GitHubOrganization
+from otterdog.webapp.blueprints import Blueprint, BlueprintType
+from otterdog.webapp.db.service import get_configuration_by_github_id, get_installation_by_github_id
+
+if TYPE_CHECKING:
+    from otterdog.models.repository import Repository
+    from otterdog.webapp.db.models import ConfigurationModel
+
+
+class AppendConfigurationBlueprint(Blueprint):
+    condition: str
+    content: str
+
+    @property
+    def type(self) -> BlueprintType:
+        return BlueprintType.APPEND_CONFIGURATION
+
+    async def _get_repositories(self, config_model: ConfigurationModel) -> list[Repository]:
+        installation_model = await get_installation_by_github_id(config_model.github_id)
+        if installation_model is not None and installation_model.config_repo is not None:
+            github_organization = GitHubOrganization.from_model_data(config_model.config)
+            repo = github_organization.get_repository(installation_model.config_repo)
+            if repo is not None:
+                return [repo]
+
+        return []
+
+    def _matches(self, repo: Repository) -> bool:
+        return True
+
+    async def evaluate_repo(
+        self,
+        installation_id: int,
+        github_id: str,
+        repo_name: str,
+        config: ConfigurationModel | None = None,
+    ) -> None:
+        from otterdog.webapp.tasks.blueprints.append_configuration import AppendConfigurationTask
+
+        config_model = await get_configuration_by_github_id(github_id) if config is None else config
+        assert config_model is not None
+
+        current_app.add_background_task(
+            AppendConfigurationTask(
+                installation_id,
+                github_id,
+                repo_name,
+                self,
+                config_model,
+            )
+        )

--- a/otterdog/webapp/blueprints/append_configuration.py
+++ b/otterdog/webapp/blueprints/append_configuration.py
@@ -19,6 +19,7 @@ from otterdog.webapp.db.service import get_configuration_by_github_id, get_insta
 if TYPE_CHECKING:
     from otterdog.models.repository import Repository
     from otterdog.webapp.db.models import ConfigurationModel
+    from otterdog.webapp.webhook.github_models import Commit
 
 
 class AppendConfigurationBlueprint(Blueprint):
@@ -41,6 +42,14 @@ class AppendConfigurationBlueprint(Blueprint):
 
     def _matches(self, repo: Repository) -> bool:
         return True
+
+    def should_reevaluate(self, commits: list[Commit]) -> bool:
+        from otterdog.webapp.webhook.github_models import touched_by_commits
+
+        def is_configuration_path(path: str) -> bool:
+            return path.startswith("otterdog/") and path.endswith(".jsonnet")
+
+        return touched_by_commits(is_configuration_path, commits)
 
     async def evaluate_repo(
         self,

--- a/otterdog/webapp/blueprints/pin_workflow.py
+++ b/otterdog/webapp/blueprints/pin_workflow.py
@@ -17,6 +17,7 @@ from otterdog.webapp.blueprints import Blueprint, BlueprintType, RepoSelector
 if TYPE_CHECKING:
     from otterdog.models.repository import Repository
     from otterdog.webapp.db.models import ConfigurationModel
+    from otterdog.webapp.webhook.github_models import Commit
 
 
 class PinWorkflowBlueprint(Blueprint):
@@ -31,6 +32,14 @@ class PinWorkflowBlueprint(Blueprint):
             return True
         else:
             return self.repo_selector.matches(repo)
+
+    def should_reevaluate(self, commits: list[Commit]) -> bool:
+        from otterdog.webapp.webhook.github_models import touched_by_commits
+
+        def is_workflow_path(path: str) -> bool:
+            return path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml"))
+
+        return touched_by_commits(is_workflow_path, commits)
 
     async def evaluate_repo(
         self,

--- a/otterdog/webapp/tasks/blueprints/__init__.py
+++ b/otterdog/webapp/tasks/blueprints/__init__.py
@@ -127,8 +127,8 @@ class BlueprintTask(InstallationBasedTask, Task[CheckResult], ABC):
         )
 
         pr_body = (
-            f"This PR has automatically been created by Otterdog due to "
-            f"configured blueprint [{self.blueprint.name}]({self.blueprint.path})."
+            f"This PR has been created automatically by Otterdog due to "
+            f"the following blueprint: [{self.blueprint.name}]({self.blueprint.path})."
         )
 
         if self.blueprint.description is not None:

--- a/otterdog/webapp/tasks/blueprints/append_configuration.py
+++ b/otterdog/webapp/tasks/blueprints/append_configuration.py
@@ -1,0 +1,138 @@
+#  *******************************************************************************
+#  Copyright (c) 2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from dataclasses import dataclass
+from functools import cached_property
+
+import aiofiles
+
+from otterdog.models.github_organization import GitHubOrganization
+from otterdog.utils import jsonnet_evaluate_file, query_json
+from otterdog.webapp.blueprints.append_configuration import AppendConfigurationBlueprint
+from otterdog.webapp.db.models import ConfigurationModel
+from otterdog.webapp.tasks.blueprints import BlueprintTask, CheckResult
+
+
+@dataclass(repr=False)
+class AppendConfigurationTask(BlueprintTask):
+    installation_id: int
+    org_id: str
+    repo_name: str
+    blueprint: AppendConfigurationBlueprint
+    config_model: ConfigurationModel
+
+    @cached_property
+    def github_organization_configuration(self) -> GitHubOrganization:
+        return GitHubOrganization.from_model_data(self.config_model.config)
+
+    async def _execute(self) -> CheckResult:
+        self.logger.info(
+            "checking configuration for blueprint '%s' in repo '%s/%s'",
+            self.blueprint.id,
+            self.org_id,
+            self.repo_name,
+        )
+
+        result = CheckResult(remediation_needed=False)
+
+        try:
+            query_result = query_json(self.blueprint.condition, self.config_model.config)
+            if query_result is True:
+                return result
+            elif query_result is False:
+                # condition failed, so we need to remediate
+                pass
+            else:
+                # something unexpected happened wrong when checking the condition
+                # result is not a boolean
+                self.logger.error(
+                    "checking condition of blueprint '%s' for repo '%s/%s' resulting in: %s",
+                    self.blueprint.id,
+                    self.org_id,
+                    self.repo_name,
+                    query_result,
+                )
+                result.check_failed = True
+                return result
+        except RuntimeError as ex:
+            self.logger.error(
+                "error while checking for condition of blueprint '%s' in repo '%s/%s'",
+                self.blueprint.id,
+                self.org_id,
+                self.repo_name,
+                exc_info=ex,
+            )
+            result.check_failed = True
+            return result
+
+        await self._process_blueprint(result)
+        return result
+
+    def _render_configuration_snippet(self, snippet: str) -> str:
+        import chevron
+
+        context = {
+            "project_name": self.config_model.project_name,
+            "github_id": self.config_model.github_id,
+            "repo_name": self.repo_name,
+            "org": self.github_organization_configuration.settings,
+            "repo": self.github_organization_configuration.get_repository(self.repo_name),
+            "repo_url": f"https://github.com/{self.org_id}/{self.repo_name}",
+            "blueprint_id": self.blueprint.id,
+            "blueprint_url": self.blueprint.path,
+        }
+
+        return chevron.render(snippet, context)
+
+    async def _process_blueprint(self, result: CheckResult) -> None:
+        result.remediation_needed = True
+
+        async with self.get_organization_config() as org_config:
+            rest_api = await self.rest_api
+
+            default_branch = await rest_api.repo.get_default_branch(self.org_id, self.repo_name)
+            await self._create_branch_if_needed(default_branch)
+
+            config_path = f"otterdog/{self.org_id}.jsonnet"
+            current_configuration = await rest_api.content.get_content(self.org_id, self.repo_name, config_path)
+
+            patched_configuration = (
+                current_configuration.rstrip() + " + " + self._render_configuration_snippet(self.blueprint.content)
+            )
+            patched_config_file = org_config.jsonnet_config.org_config_file + "-PATCH"
+
+            async with aiofiles.open(patched_config_file, "w") as file:
+                await file.write(patched_configuration)
+
+            try:
+                jsonnet_evaluate_file(patched_config_file)
+            except RuntimeError as ex:
+                self.logger.error("failed to evaluate patched configuration", exc_info=ex)
+                result.check_failed = True
+                return
+
+            # update content in the branch if necessary
+            await rest_api.content.update_content(
+                self.org_id,
+                self.repo_name,
+                config_path,
+                patched_configuration,
+                self.branch_name,
+                "Updating configuration",
+            )
+
+        existing_pr_number = await self._find_existing_pull_request(default_branch)
+        if existing_pr_number is not None:
+            result.remediation_pr = existing_pr_number
+            return
+
+        pr_title = f"chore(otterdog): updating configuration due to blueprint `{self.blueprint.id}`"
+        result.remediation_pr = await self._create_pull_request(pr_title, default_branch)
+
+    def __repr__(self) -> str:
+        return f"AppendConfigurationTask(repo='{self.org_id}/{self.repo_name}', blueprint='{self.blueprint.id}')"

--- a/otterdog/webapp/tasks/blueprints/append_configuration.py
+++ b/otterdog/webapp/tasks/blueprints/append_configuration.py
@@ -41,14 +41,18 @@ class AppendConfigurationTask(BlueprintTask):
         result = CheckResult(remediation_needed=False)
 
         try:
+            # evaluate the condition:
+            # - true: the snippet should be added
+            # - false: nothing to be done
+            # - else: report a failure, the condition did not produce a boolean result
             query_result = query_json(self.blueprint.condition, self.config_model.config)
-            if query_result is True:
+            if query_result is False:
                 return result
-            elif query_result is False:
-                # condition failed, so we need to remediate
+            elif query_result is True:
+                # condition succeeded, so we need to remediate
                 pass
             else:
-                # something unexpected happened wrong when checking the condition
+                # something unexpected happened when checking the condition
                 # result is not a boolean
                 self.logger.error(
                     "checking condition of blueprint '%s' for repo '%s/%s' resulting in: %s",

--- a/otterdog/webapp/webhook/__init__.py
+++ b/otterdog/webapp/webhook/__init__.py
@@ -255,23 +255,27 @@ async def on_push_received(data):
         org_id = event.organization.login
         repo_name = event.repository.name
 
-        # check any blueprint that matches the repo that just got a new push on the default branch
-        for blueprint_status_model in await get_blueprints_status_for_repo(org_id, repo_name):
-            blueprint_model = await find_blueprint(org_id, blueprint_status_model.id.blueprint_id)
-            if blueprint_model is not None:
-                blueprint_instance = create_blueprint_from_model(blueprint_model)
-                await blueprint_instance.evaluate_repo(installation_id, org_id, repo_name)
+        config_repo_touched = await targets_config_repo(repo_name, installation_id)
 
-        if not await targets_config_repo(repo_name, installation_id):
+        async def fetch_config_and_check_blueprints_if_needed() -> None:
+            if config_repo_touched:
+                await FetchConfigTask(
+                    event.installation.id,
+                    event.organization.login,
+                    event.repository.name,
+                ).execute()
+
+            # check any blueprint that matches the repo that just got a new push on the default branch
+            for blueprint_status_model in await get_blueprints_status_for_repo(org_id, repo_name):
+                blueprint_model = await find_blueprint(org_id, blueprint_status_model.id.blueprint_id)
+                if blueprint_model is not None:
+                    blueprint_instance = create_blueprint_from_model(blueprint_model)
+                    await blueprint_instance.evaluate_repo(installation_id, org_id, repo_name)
+
+        current_app.add_background_task(fetch_config_and_check_blueprints_if_needed)
+
+        if not config_repo_touched:
             return success()
-
-        current_app.add_background_task(
-            FetchConfigTask(
-                event.installation.id,
-                event.organization.login,
-                event.repository.name,
-            )
-        )
 
         def modifies_any_policy(commit: Commit) -> bool:
             return (

--- a/otterdog/webapp/webhook/github_models.py
+++ b/otterdog/webapp/webhook/github_models.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
 
@@ -244,3 +245,14 @@ class WorkflowJobEvent(Event):
     action: str
     workflow_job: WorkflowJob
     repository: Repository
+
+
+def touched_by_commits(predicate: Callable[[str], bool], commits: list[Commit]):
+    def touched(commit: Commit) -> bool:
+        return (
+            any(map(predicate, commit.added))
+            or any(map(predicate, commit.modified))
+            or any(map(predicate, commit.removed))
+        )
+
+    return any(map(touched, commits))

--- a/poetry.lock
+++ b/poetry.lock
@@ -2689,29 +2689,29 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.7.4"
+version = "0.8.0"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.7.4-py3-none-linux_armv6l.whl", hash = "sha256:a4919925e7684a3f18e18243cd6bea7cfb8e968a6eaa8437971f681b7ec51478"},
-    {file = "ruff-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cfb365c135b830778dda8c04fb7d4280ed0b984e1aec27f574445231e20d6c63"},
-    {file = "ruff-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:63a569b36bc66fbadec5beaa539dd81e0527cb258b94e29e0531ce41bacc1f20"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d06218747d361d06fd2fdac734e7fa92df36df93035db3dc2ad7aa9852cb109"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0cea28d0944f74ebc33e9f934238f15c758841f9f5edd180b5315c203293452"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80094ecd4793c68b2571b128f91754d60f692d64bc0d7272ec9197fdd09bf9ea"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:997512325c6620d1c4c2b15db49ef59543ef9cd0f4aa8065ec2ae5103cedc7e7"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00b4cf3a6b5fad6d1a66e7574d78956bbd09abfd6c8a997798f01f5da3d46a05"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7dbdc7d8274e1422722933d1edddfdc65b4336abf0b16dfcb9dedd6e6a517d06"},
-    {file = "ruff-0.7.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e92dfb5f00eaedb1501b2f906ccabfd67b2355bdf117fea9719fc99ac2145bc"},
-    {file = "ruff-0.7.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3bd726099f277d735dc38900b6a8d6cf070f80828877941983a57bca1cd92172"},
-    {file = "ruff-0.7.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2e32829c429dd081ee5ba39aef436603e5b22335c3d3fff013cd585806a6486a"},
-    {file = "ruff-0.7.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:662a63b4971807623f6f90c1fb664613f67cc182dc4d991471c23c541fee62dd"},
-    {file = "ruff-0.7.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:876f5e09eaae3eb76814c1d3b68879891d6fde4824c015d48e7a7da4cf066a3a"},
-    {file = "ruff-0.7.4-py3-none-win32.whl", hash = "sha256:75c53f54904be42dd52a548728a5b572344b50d9b2873d13a3f8c5e3b91f5cac"},
-    {file = "ruff-0.7.4-py3-none-win_amd64.whl", hash = "sha256:745775c7b39f914238ed1f1b0bebed0b9155a17cd8bc0b08d3c87e4703b990d6"},
-    {file = "ruff-0.7.4-py3-none-win_arm64.whl", hash = "sha256:11bff065102c3ae9d3ea4dc9ecdfe5a5171349cdd0787c1fc64761212fc9cf1f"},
-    {file = "ruff-0.7.4.tar.gz", hash = "sha256:cd12e35031f5af6b9b93715d8c4f40360070b2041f81273d0527683d5708fce2"},
+    {file = "ruff-0.8.0-py3-none-linux_armv6l.whl", hash = "sha256:fcb1bf2cc6706adae9d79c8d86478677e3bbd4ced796ccad106fd4776d395fea"},
+    {file = "ruff-0.8.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:295bb4c02d58ff2ef4378a1870c20af30723013f441c9d1637a008baaf928c8b"},
+    {file = "ruff-0.8.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7b1f1c76b47c18fa92ee78b60d2d20d7e866c55ee603e7d19c1e991fad933a9a"},
+    {file = "ruff-0.8.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb0d4f250a7711b67ad513fde67e8870109e5ce590a801c3722580fe98c33a99"},
+    {file = "ruff-0.8.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e55cce9aa93c5d0d4e3937e47b169035c7e91c8655b0974e61bb79cf398d49c"},
+    {file = "ruff-0.8.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f4cd64916d8e732ce6b87f3f5296a8942d285bbbc161acee7fe561134af64f9"},
+    {file = "ruff-0.8.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c5c1466be2a2ebdf7c5450dd5d980cc87c8ba6976fb82582fea18823da6fa362"},
+    {file = "ruff-0.8.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2dabfd05b96b7b8f2da00d53c514eea842bff83e41e1cceb08ae1966254a51df"},
+    {file = "ruff-0.8.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:facebdfe5a5af6b1588a1d26d170635ead6892d0e314477e80256ef4a8470cf3"},
+    {file = "ruff-0.8.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87a8e86bae0dbd749c815211ca11e3a7bd559b9710746c559ed63106d382bd9c"},
+    {file = "ruff-0.8.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85e654f0ded7befe2d61eeaf3d3b1e4ef3894469cd664ffa85006c7720f1e4a2"},
+    {file = "ruff-0.8.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:83a55679c4cb449fa527b8497cadf54f076603cc36779b2170b24f704171ce70"},
+    {file = "ruff-0.8.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:812e2052121634cf13cd6fddf0c1871d0ead1aad40a1a258753c04c18bb71bbd"},
+    {file = "ruff-0.8.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:780d5d8523c04202184405e60c98d7595bdb498c3c6abba3b6d4cdf2ca2af426"},
+    {file = "ruff-0.8.0-py3-none-win32.whl", hash = "sha256:5fdb6efecc3eb60bba5819679466471fd7d13c53487df7248d6e27146e985468"},
+    {file = "ruff-0.8.0-py3-none-win_amd64.whl", hash = "sha256:582891c57b96228d146725975fbb942e1f30a0c4ba19722e692ca3eb25cc9b4f"},
+    {file = "ruff-0.8.0-py3-none-win_arm64.whl", hash = "sha256:ba93e6294e9a737cd726b74b09a6972e36bb511f9a102f1d9a7e1ce94dd206a6"},
+    {file = "ruff-0.8.0.tar.gz", hash = "sha256:a7ccfe6331bf8c8dad715753e157457faf7351c2b69f62f32c165c2dbcbacd44"},
 ]
 
 [[package]]
@@ -3161,4 +3161,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11, <4.0"
-content-hash = "71d13456f608b4dbfe179f52b010aa68a0ba319e20215431e16e81632ed56773"
+content-hash = "44d3be0bc71c1c7dfa5f38ac582c9a0e395ba2f61daec03f2d1347a9c5daa415"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ semver               = "^3.0"
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-ruff       = "^0.7"
+ruff       = "^0.8"
 mypy       = "^1.8"
 pre-commit = "^4.0"
 

--- a/tests/webapp/blueprints/test_append_configuration.py
+++ b/tests/webapp/blueprints/test_append_configuration.py
@@ -1,0 +1,51 @@
+#  *******************************************************************************
+#  Copyright (c) 2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+
+import yaml
+
+from otterdog.webapp.blueprints import BlueprintType, read_blueprint
+from otterdog.webapp.blueprints.append_configuration import AppendConfigurationBlueprint
+
+yaml_content = """
+id: prevent-force-pushes
+name: Prevents force-pushes for the default branch
+type: append_configuration
+config:
+  condition: >-
+    $count($.rulesets[allows_force_pushes = false and
+    "~DEFAULT_BRANCH" in include_refs and
+    "~ALL" in include_repo_names and target = "branch"]) > 0
+  content: |-
+    {
+      # snippet added due to '{{blueprint_url}}'
+      rulesets+: [
+        orgs.newOrgRuleset('{{blueprint_id}}') {
+          allows_creations: true,
+          include_repo_names: [
+            "~ALL"
+          ],
+          include_refs: [
+            "~DEFAULT_BRANCH"
+          ],
+          required_pull_request: null,
+          required_status_checks: null,
+        },
+      ],
+    }
+"""
+
+
+def test_read():
+    config = yaml.safe_load(yaml_content)
+
+    blueprint = read_blueprint("a", config)
+    assert blueprint.type == BlueprintType.APPEND_CONFIGURATION
+
+    assert isinstance(blueprint, AppendConfigurationBlueprint)
+    assert "\n" not in blueprint.condition


### PR DESCRIPTION
This adds an append_configuration blueprint that will check if a given condition that is evaluated against the current configuration of a the project / organization is true. If false, the given configuration snippet is added via a PR.

This allows to model blueprints like

- add a .github repo if it does not exist
- add an organization ruleset to prevent force pushes