### PR TITLE
feat: add scorecard integration blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added new blueprint `scorecard_integration` to integrate OSSF Scorecard evaluations. ([#345](https://github.com/eclipse-csi/otterdog/issues/345))
 - Added new blueprint `append_configuration` to append configuration snippets depending on certain conditions.
 - Added support for organization rulesets. ([#158](https://github.com/eclipse-csi/otterdog/issues/158))
 - Added support for templates in `required-file` blueprints. ([#322](https://github.com/eclipse-csi/otterdog/issues/322))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
         - Required File: reference/blueprints/required-file.md
         - Pin Workflow: reference/blueprints/pin-workflow.md
         - Append Configuration: reference/blueprints/append-configuration.md
+        - OSSF Scorecard Integration: reference/blueprints/scorecard-integration.md
 
     - CLI Operations:
         - reference/operations/index.md

--- a/otterdog/webapp/api/routes.py
+++ b/otterdog/webapp/api/routes.py
@@ -15,6 +15,7 @@ from otterdog.webapp.db.service import (
     get_configuration_by_project_name,
     get_installations,
     get_merged_pull_requests_paged,
+    get_scorecard_results_paged,
     get_tasks_paged,
 )
 
@@ -59,6 +60,20 @@ async def tasks():
 async def merged_pullrequests():
     paged_pull_requests, count = await get_merged_pull_requests_paged(request.args.to_dict())
     result = {"data": [x.model_dump() for x in paged_pull_requests], "itemsCount": count}
+    return jsonify(result)
+
+
+@blueprint.route("/scorecard/results")
+async def scorecard_results():
+    paged_scorecard_results, count = await get_scorecard_results_paged(request.args.to_dict())
+
+    def json_transform(m):
+        json = m.model_dump()
+        for check in json["checks"]:
+            json.update({check["name"]: check["score"]})
+        return json
+
+    result = {"data": [json_transform(x) for x in paged_scorecard_results], "itemsCount": count}
     return jsonify(result)
 
 

--- a/otterdog/webapp/blueprints/scorecard_integration.py
+++ b/otterdog/webapp/blueprints/scorecard_integration.py
@@ -1,0 +1,83 @@
+#  *******************************************************************************
+#  Copyright (c) 2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from quart import current_app
+
+from otterdog.webapp.blueprints import Blueprint, BlueprintType, RepoSelector
+from otterdog.webapp.db.service import get_configuration_by_github_id
+
+if TYPE_CHECKING:
+    from otterdog.models.repository import Repository
+    from otterdog.webapp.db.models import ConfigurationModel
+    from otterdog.webapp.webhook.github_models import Commit
+
+
+class ScorecardIntegrationBlueprint(Blueprint):
+    repo_selector: RepoSelector | None = None
+    scorecard_action: str = "ossf/scorecard-action"
+    workflow_name: str = "scorecard-analysis.yml"
+    workflow_content: str
+
+    @property
+    def type(self) -> BlueprintType:
+        return BlueprintType.SCORECARD_INTEGRATION
+
+    def _matches(self, repo: Repository) -> bool:
+        if self.repo_selector is None:
+            return True
+        else:
+            return self.repo_selector.matches(repo)
+
+    def should_reevaluate(self, commits: list[Commit]) -> bool:
+        from otterdog.webapp.webhook.github_models import touched_by_commits
+
+        def is_workflow_path(path: str) -> bool:
+            return path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml"))
+
+        return touched_by_commits(is_workflow_path, commits)
+
+    async def evaluate_repo(
+        self,
+        installation_id: int,
+        github_id: str,
+        repo_name: str,
+        config: ConfigurationModel | None = None,
+    ) -> None:
+        from otterdog.webapp.tasks.blueprints.check_scorecard_integration import CheckScorecardIntegrationTask
+
+        config_model = await get_configuration_by_github_id(github_id) if config is None else config
+        if config_model is None:
+            self.logger.warning(
+                f"evaluating_repo for blueprint with id '{self.id}': no configuration found for github_id '{github_id}'"
+            )
+            return
+
+        current_app.add_background_task(
+            CheckScorecardIntegrationTask(
+                installation_id,
+                github_id,
+                repo_name,
+                self,
+                config_model,
+            )
+        )
+
+    async def collect_auxiliary_data(self, installation_id: int, github_id: str, repo_name: str) -> None:
+        from otterdog.webapp.tasks.blueprints.sync_scorecard_result import SyncScorecardResultTask
+
+        current_app.add_background_task(
+            SyncScorecardResultTask(
+                installation_id,
+                github_id,
+                repo_name,
+            )
+        )

--- a/otterdog/webapp/db/__init__.py
+++ b/otterdog/webapp/db/__init__.py
@@ -48,6 +48,7 @@ async def init_mongo_database(mongo: Mongo) -> None:
         PolicyModel,
         PolicyStatusModel,
         PullRequestModel,
+        ScorecardResultModel,
         StatisticsModel,
         TaskModel,
         UserModel,
@@ -65,5 +66,6 @@ async def init_mongo_database(mongo: Mongo) -> None:
             PolicyStatusModel,
             BlueprintModel,
             BlueprintStatusModel,
+            ScorecardResultModel,
         ]  # type: ignore
     )

--- a/otterdog/webapp/db/models.py
+++ b/otterdog/webapp/db/models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from odmantic import EmbeddedModel, Field, Model
 
@@ -210,3 +210,4 @@ class ScorecardResultModel(Model):
     updated_at: datetime = Field(index=True, default_factory=current_utc_time)
     score: Optional[float] = None
     scorecard_version: Optional[str] = None
+    checks: list[dict[str, Any]] = Field(default_factory=list)

--- a/otterdog/webapp/db/models.py
+++ b/otterdog/webapp/db/models.py
@@ -197,3 +197,16 @@ class BlueprintStatusModel(Model):
     updated_at: datetime = Field(index=True, default_factory=current_utc_time)
     status: BlueprintStatus = Field(default=BlueprintStatus.NOT_CHECKED)
     remediation_pr: Optional[int] = Field(index=True, default=None)
+
+
+class ScorecardId(EmbeddedModel):
+    org_id: str
+    repo_name: str
+
+
+class ScorecardResultModel(Model):
+    id: ScorecardId = Field(primary_field=True)
+
+    updated_at: datetime = Field(index=True, default_factory=current_utc_time)
+    score: Optional[float] = None
+    scorecard_version: Optional[str] = None

--- a/otterdog/webapp/db/service.py
+++ b/otterdog/webapp/db/service.py
@@ -49,6 +49,8 @@ from .models import (
 )
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from odmantic.query import QueryExpression
 
     from otterdog.config import OtterdogConfig
@@ -894,8 +896,10 @@ async def find_scorecard_result(owner: str, repo_name: str) -> ScorecardResultMo
 async def update_or_create_scorecard_result(
     owner: str,
     repo_name: str,
+    date: datetime,
     score: float,
     scorecard_version: str,
+    checks: list[dict[str, Any]],
 ) -> None:
     scorecard_result_model = await find_scorecard_result(owner, repo_name)
     if scorecard_result_model is None:
@@ -903,7 +907,65 @@ async def update_or_create_scorecard_result(
             id=ScorecardId(org_id=owner, repo_name=repo_name),
         )
 
+    scorecard_result_model.updated_at = date
     scorecard_result_model.score = score
     scorecard_result_model.scorecard_version = scorecard_version
+    scorecard_result_model.checks = checks
 
     await mongo.odm.save(scorecard_result_model)
+
+
+async def get_scorecard_results_paged(params: dict[str, str]) -> tuple[list[ScorecardResultModel], int]:
+    page_index = 1
+    page_size = 20
+    sort_field_name = "score"
+    sort_order = "desc"
+
+    queries: list[QueryExpression] = []
+
+    for k, v in params.items():
+        match k:
+            case "pageIndex":
+                page_index = int(v)
+            case "pageSize":
+                page_size = int(v)
+            case "sortField":
+                sort_field_name = v
+            case "sortOrder":
+                sort_order = v
+            case _:
+                if v:
+                    if k.startswith("id["):
+                        match k:
+                            case "id[org_id]":
+                                queries.append(query.match(ScorecardResultModel.id.org_id, v))
+                            case "id[repo_name]":
+                                queries.append(query.match(ScorecardResultModel.id.repo_name, v))
+                            case _:
+                                raise RuntimeError(f"unexpected query field '{k}'")
+                    else:
+                        queries.append(query.match(ScorecardResultModel.__dict__[k], v))
+
+    if sort_field_name.startswith("id."):
+        match sort_field_name:
+            case "id.org_id":
+                sort_field = ScorecardResultModel.id.org_id
+            case "id.repo_name":
+                sort_field = ScorecardResultModel.id.repo_name
+            case _:
+                raise RuntimeError(f"unexpected sort field '{sort_field_name}'")
+    else:
+        sort_field = ScorecardResultModel.__dict__[sort_field_name]
+
+    sort = query.desc(sort_field) if sort_order == "desc" else query.asc(sort_field)
+    skip = (page_index - 1) * page_size
+    return (
+        await mongo.odm.find(
+            ScorecardResultModel,
+            *queries,
+            skip=skip,
+            limit=page_size,
+            sort=sort,
+        ),
+        await mongo.odm.count(ScorecardResultModel, *queries),
+    )

--- a/otterdog/webapp/filters.py
+++ b/otterdog/webapp/filters.py
@@ -95,3 +95,16 @@ def register_filters(app):
     @app.template_filter("snake_to_normal")
     def snake_to_normal(value):
         return snake_to_normal_case(value)
+
+    @app.template_filter("scorecard_badge_color")
+    def scorecard_badge_color(value: float):
+        if value < 2:
+            return "red"
+        elif value < 5:
+            return "yellow"
+        elif value < 8:
+            return "yellowgreen"
+        elif value < 10:
+            return "green"
+        else:
+            return "brightgreen"

--- a/otterdog/webapp/home/routes.py
+++ b/otterdog/webapp/home/routes.py
@@ -40,7 +40,6 @@ from otterdog.webapp.db.service import (
     get_policies_status,
     get_scorecard_results,
     get_statistics,
-    get_tasks,
 )
 from otterdog.webapp.tasks import get_organization_config
 from otterdog.webapp.utils import get_project_base_url, get_temporary_base_directory
@@ -443,6 +442,11 @@ async def organizations():
     )
 
 
+@blueprint.route("/scorecard/checks")
+async def scorecards():
+    return await render_home_template("scorecards.html")
+
+
 @blueprint.route("/admin/pullrequests")
 async def pullrequests():
     open_pull_requests = await get_open_or_incomplete_pull_requests()
@@ -455,11 +459,7 @@ async def pullrequests():
 
 @blueprint.route("/admin/tasks")
 async def tasks():
-    latest_tasks = await get_tasks(100)
-    return await render_home_template(
-        "tasks.html",
-        tasks=latest_tasks,
-    )
+    return await render_home_template("tasks.html")
 
 
 @blueprint.route("/<template>")

--- a/otterdog/webapp/tasks/blueprints/check_files.py
+++ b/otterdog/webapp/tasks/blueprints/check_files.py
@@ -77,6 +77,7 @@ class CheckFilesTask(BlueprintTask):
             "org": self.github_organization_configuration.settings,
             "repo": self.github_organization_configuration.get_repository(self.repo_name),
             "repo_url": f"https://github.com/{self.org_id}/{self.repo_name}",
+            "blueprint_id": self.blueprint.id,
             "blueprint_url": self.blueprint.path,
         }
 

--- a/otterdog/webapp/tasks/blueprints/check_scorecard_integration.py
+++ b/otterdog/webapp/tasks/blueprints/check_scorecard_integration.py
@@ -1,0 +1,126 @@
+#  *******************************************************************************
+#  Copyright (c) 2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from otterdog.models.github_organization import GitHubOrganization
+from otterdog.webapp.tasks.blueprints import BlueprintTask, CheckResult
+from otterdog.webapp.tasks.blueprints.pinning.actions import ActionRef, GitHubAction
+from otterdog.webapp.tasks.blueprints.pinning.workflow_file import WorkflowFile
+
+if TYPE_CHECKING:
+    from otterdog.webapp.blueprints.scorecard_integration import ScorecardIntegrationBlueprint
+    from otterdog.webapp.db.models import ConfigurationModel
+
+
+@dataclass(repr=False)
+class CheckScorecardIntegrationTask(BlueprintTask):
+    installation_id: int
+    org_id: str
+    repo_name: str
+    blueprint: ScorecardIntegrationBlueprint
+    config_model: ConfigurationModel
+
+    @cached_property
+    def github_organization_configuration(self) -> GitHubOrganization:
+        return GitHubOrganization.from_model_data(self.config_model.config)
+
+    async def _execute(self) -> CheckResult:
+        self.logger.info(
+            "checking scorecard integration in repo '%s/%s'",
+            self.org_id,
+            self.repo_name,
+        )
+
+        result = CheckResult(remediation_needed=False)
+
+        try:
+            if not await self._find_scorecard_integration():
+                await self._add_scorecard_workflow(result)
+        except RuntimeError:
+            result.check_failed = True
+            return result
+
+        return result
+
+    async def _find_scorecard_integration(self) -> bool:
+        rest_api = await self.rest_api
+
+        workflows = await rest_api.action.get_workflows(self.org_id, self.repo_name)
+
+        for workflow in workflows:
+            workflow_path: str = workflow["path"]
+            if not workflow_path.startswith(".github"):
+                continue
+
+            try:
+                workflow_content = await rest_api.content.get_content(self.org_id, self.repo_name, workflow_path)
+                workflow = WorkflowFile(workflow_content)
+                referenced_actions = set(workflow.get_used_actions())
+                for action in referenced_actions:
+                    action_ref = ActionRef.of_pattern(action)
+                    if isinstance(action_ref, GitHubAction):
+                        referenced_action = f"{action_ref.owner}/{action_ref.repo}"
+                        if referenced_action == self.blueprint.scorecard_action:
+                            return True
+            except RuntimeError:
+                continue
+
+        return False
+
+    def _render_content(self, content: str) -> str:
+        import chevron
+
+        context = {
+            "project_name": self.config_model.project_name,
+            "github_id": self.config_model.github_id,
+            "repo_name": self.repo_name,
+            "org": self.github_organization_configuration.settings,
+            "repo": self.github_organization_configuration.get_repository(self.repo_name),
+            "repo_url": f"https://github.com/{self.org_id}/{self.repo_name}",
+            "blueprint_id": self.blueprint.id,
+            "blueprint_url": self.blueprint.path,
+        }
+
+        return chevron.render(content, context)
+
+    async def _add_scorecard_workflow(
+        self,
+        result: CheckResult,
+    ) -> None:
+        result.remediation_needed = True
+
+        rest_api = await self.rest_api
+        default_branch = await rest_api.repo.get_default_branch(self.org_id, self.repo_name)
+
+        await self._create_branch_if_needed(default_branch)
+
+        workflow_path = f".github/workflows/{self.blueprint.workflow_name}"
+        await rest_api.content.update_content(
+            self.org_id,
+            self.repo_name,
+            workflow_path,
+            self._render_content(self.blueprint.workflow_content),
+            self.branch_name,
+            f"Adding scorecard analysis workflow {workflow_path}",
+        )
+
+        existing_pr_number = await self._find_existing_pull_request(default_branch)
+        if existing_pr_number is not None:
+            result.remediation_pr = existing_pr_number
+            return
+
+        pr_title = f"chore(otterdog): adding scorecard analysis workflow due to blueprint `{self.blueprint.id}`"
+        result.remediation_pr = await self._create_pull_request(pr_title, default_branch)
+
+    def __repr__(self) -> str:
+        return f"CheckScorecardIntegrationTask(repo='{self.org_id}/{self.repo_name}')"

--- a/otterdog/webapp/tasks/blueprints/sync_scorecard_result.py
+++ b/otterdog/webapp/tasks/blueprints/sync_scorecard_result.py
@@ -1,0 +1,55 @@
+#  *******************************************************************************
+#  Copyright (c) 2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from dataclasses import dataclass
+
+from aiohttp import ClientSession
+
+from otterdog.webapp.db.models import TaskModel
+from otterdog.webapp.db.service import (
+    update_or_create_scorecard_result,
+)
+from otterdog.webapp.tasks import (
+    InstallationBasedTask,
+    Task,
+)
+
+
+@dataclass(repr=False)
+class SyncScorecardResultTask(InstallationBasedTask, Task[None]):
+    installation_id: int
+    org_id: str
+    repo_name: str
+
+    def create_task_model(self):
+        return TaskModel(
+            type=type(self).__name__,
+            org_id=self.org_id,
+            repo_name=self.repo_name,
+        )
+
+    async def _execute(self) -> None:
+        self.logger.info(
+            "syncing scorecard results for repo '%s/%s'",
+            self.org_id,
+            self.repo_name,
+        )
+
+        headers = {"accept": "application/json"}
+
+        scorecard_url = f"https://api.securityscorecards.dev/projects/github.com/{self.org_id}/{self.repo_name}"
+        async with ClientSession() as session, session.get(scorecard_url, headers=headers) as response:
+            if response.ok:
+                json_response = await response.json()
+                score = json_response["score"]
+                scorecard_version = json_response["scorecard"]["version"]
+
+                await update_or_create_scorecard_result(self.org_id, self.repo_name, score, scorecard_version)
+
+    def __repr__(self) -> str:
+        return f"SyncScorecardResultTask(repo={self.org_id}/{self.repo_name})"

--- a/otterdog/webapp/tasks/blueprints/sync_scorecard_result.py
+++ b/otterdog/webapp/tasks/blueprints/sync_scorecard_result.py
@@ -7,6 +7,7 @@
 #  *******************************************************************************
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from aiohttp import ClientSession
 
@@ -46,10 +47,19 @@ class SyncScorecardResultTask(InstallationBasedTask, Task[None]):
         async with ClientSession() as session, session.get(scorecard_url, headers=headers) as response:
             if response.ok:
                 json_response = await response.json()
+                date = datetime.fromisoformat(json_response["date"])
                 score = json_response["score"]
                 scorecard_version = json_response["scorecard"]["version"]
+                checks = json_response["checks"]
 
-                await update_or_create_scorecard_result(self.org_id, self.repo_name, score, scorecard_version)
+                await update_or_create_scorecard_result(
+                    self.org_id,
+                    self.repo_name,
+                    date,
+                    score,
+                    scorecard_version,
+                    checks,
+                )
 
     def __repr__(self) -> str:
         return f"SyncScorecardResultTask(repo={self.org_id}/{self.repo_name})"

--- a/otterdog/webapp/templates/home/organization.html
+++ b/otterdog/webapp/templates/home/organization.html
@@ -567,6 +567,7 @@
                             <th class="text-center">Webhooks</th>
                             <th class="text-center">Secret Scanning</th>
                             <th class="text-center">Private Vulnerability Reporting</th>
+                            <th class="text-center">OSSF Scorecard</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -637,6 +638,16 @@
                               <i class="text-warning fa-solid fa-circle-xmark"></i>
                               {% else %}
                               <i class="text-muted fa-solid fa-circle"></i>
+                              {% endif %}
+                            </td>
+                            <td class="text-center">
+                              {% if repo.name in scorecard_results %}
+                              {% set result = scorecard_results[repo.name] %}
+                              <a href="https://scorecard.dev/viewer/?uri=github.com/{{ config.github_id }}/{{ repo.name }}" target="_blank">
+                                <span title="Scorecard" class="badge" style="background-color:{{ result.score | scorecard_badge_color}}; color: white;">{{ result.score }}</span>
+                              </a>
+                              {% else %}
+                              <span title="Scorecard" class="badge bg-secondary">N/A</span>
                               {% endif %}
                             </td>
                           </tr>

--- a/otterdog/webapp/templates/home/repository.html
+++ b/otterdog/webapp/templates/home/repository.html
@@ -92,6 +92,17 @@
                           <span class="float-right">{{ repo_name }}</span>
                         </a>
                       </li>
+                      <li class="nav-item">
+                        {% if scorecard_result %}
+                        <a href="https://scorecard.dev/viewer/?uri=github.com/{{ github_id }}/{{ repo_name }}" class="nav-link" target="_blank">
+                          OSSF Scorecard <span class="float-right badge" style="background-color:{{ scorecard_result.score | scorecard_badge_color }}; color: white;">{{ scorecard_result.score }}</span>
+                        </a>
+                        {% else %}
+                        <a href="#" class="nav-link tab-link" target="_blank">
+                          OSSF Scorecard <span class="float-right badge badge-secondary">N/A</span>
+                        </a>
+                        {% endif %}
+                      </li>
                       {% if repo_config.private_vulnerability_reporting_enabled != null %}
                       <li class="nav-item">
                         <a href="#settings" class="nav-link tab-link">

--- a/otterdog/webapp/templates/home/scorecards.html
+++ b/otterdog/webapp/templates/home/scorecards.html
@@ -1,0 +1,253 @@
+{% extends "layouts/base.html" %}
+
+{% block title %} OSSF Scorecard Checks {% endblock %}
+
+<!-- Element injected in the BODY element -->
+{% block body_class %} {% endblock body_class %}
+
+<!-- Specific Page CSS goes HERE  -->
+{% block stylesheets %}
+  {{ super() }}
+  <!-- jsGrid -->
+  <link rel="stylesheet" href="/assets/vendor/jsgrid/jsgrid.min.css">
+  <link rel="stylesheet" href="/assets/vendor/jsgrid/jsgrid-theme.min.css">
+
+  <style>
+    .jsgrid-header-cell { font-size: 11px; }
+    .simple-badge {
+      border-bottom-width: 3px;
+      border-bottom-style: solid;
+      border-radius: 0;
+    }
+  </style>
+{% endblock stylesheets %}
+
+{% block content %}
+
+  <!-- Content Wrapper. Contains page content -->
+  <div class="content-wrapper">
+    <!-- Content Header (Page header) -->
+    <section class="content-header">
+      <div class="container-fluid">
+        <div class="row mb-2">
+          <div class="col-sm-6">
+            <h1>OSSF Scorecards</h1>
+          </div>
+          <div class="col-sm-6">
+            <ol class="breadcrumb float-sm-right">
+              <li class="breadcrumb-item"><a href="/index">Home</a></li>
+              <li class="breadcrumb-item active">OSSF Scorecard Checks</li>
+            </ol>
+          </div>
+        </div>
+      </div><!-- /.container-fluid -->
+    </section>
+
+    <!-- Main content -->
+    <section class="content">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-12">
+            <div class="card">
+              <div class="card-header">
+              </div>
+              <!-- /.card-header -->
+              <div class="card-body">
+                <div id="taskGrid"></div>
+              </div>
+              <!-- /.card-body -->
+            </div>
+            <!-- /.card -->
+          </div>
+          <!-- /.col -->
+        </div>
+        <!-- /.row -->
+      </div>
+      <!-- /.container-fluid -->
+    </section>
+    <!-- /.content -->
+  </div>
+
+{% endblock content %}
+
+<!-- Specific Page JS goes HERE  -->
+{% block javascripts %}
+  {{ super() }}
+  <!-- jsGrid -->
+  <script src="/assets/vendor/moment/moment.min.js"></script>
+  <script src="/assets/vendor/jsgrid/jsgrid.min.js"></script>
+
+  <!-- page script -->
+  <script>
+    var DateField = function (config) {
+      jsGrid.Field.call(this, config);
+    };
+
+    DateField.prototype = new jsGrid.Field({
+      sorter: function (date1, date2) {
+        return moment(date1) - moment(date2);
+      },
+      itemTemplate: function (value) {
+        return moment(value).locale('en').format('YYYY-MM-DD HH:mm:ss.SSS');
+      },
+    });
+
+    var renderScore = function(value) {
+      if (value < 0) {
+        return "?";
+      } else {
+        return value.toString();
+      }
+    }
+
+    var renderColor = function(value) {
+        if (value < 2) {
+            return "red";
+        } else if (value < 5) {
+            return "yellow";
+        } else if (value < 8) {
+            return "#9ACD32";
+        } else if (value < 10) {
+            return "green";
+        } else {
+            return "#66FF00";
+        }
+    }
+
+    jsGrid.fields.date = DateField;
+
+    $(function () {
+      $("#taskGrid").jsGrid({
+          height: "auto",
+          width: "100%",
+
+          pageSize: 20,
+
+          filtering: true,
+          sorting: true,
+          paging: true,
+          pageLoading: true,
+          autoload: true,
+
+          controller: {
+              loadData: function(filter) {
+                  var d = $.Deferred();
+
+                  $.ajax({
+                      url: "/api/scorecard/results",
+                      data: filter,
+                      dataType: "json"
+                  }).done(function(response) {
+                      d.resolve(response);
+                  });
+
+                  return d.promise();
+              }
+          },
+
+          rowClick: function(arg) {
+            window.open('https://scorecard.dev/viewer/?uri=github.com/' + arg.item.id.org_id + '/' + arg.item.id.repo_name, '_blank').focus();
+          },
+
+          fields: [
+              { name: "id.org_id", title: "GitHub Organization", type: "text", width: 70,
+                itemTemplate: function(value, item) {
+                  return "<a href='https://github.com/" + value + "'>" + value + "</a>";
+                }
+              },
+              { name: "id.repo_name", title: "Repo name", type: "text", width: 50,
+                itemTemplate: function(value, item) {
+                  return "<a href='https://github.com/" + item.id.org_id + "/" + value + "'>" + value + "</a>";
+                }
+              },
+              { name: "score", title: "Overall Score", type: "number", width: 25, align: "center", filtering: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge' style='background-color:" + renderColor(value) + ";color: white;'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Signed-Releases", title: "Signed Releases", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Dangerous-Workflow", title: "Workflows", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Branch-Protection", title: "Branch Protections", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Code-Review", title: "Code Reviews", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Maintained", title: "Maintained", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Token-Permissions", title: "Token Permissions", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Binary-Artifacts", title: "Binary Artifacts", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Dependency-Update-Tool", title: "Dependency Update Tool", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Vulnerabilities", title: "Vuln", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Packaging", title: "Packaging", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Security-Policy", title: "Security Policy", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "SAST", title: "Static Code Analysis", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Pinned-Dependencies", title: "Pinned Dependencies", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "CI-Tests", title: "CI Tests", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "Contributors", title: "Contributors", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              },
+              { name: "License", title: "License", type: "number", width: 25, align: "center", filtering: false, sorting: false,
+                itemTemplate: function(value, item) {
+                  return "<span class='badge simple-badge' style='border-color:" + renderColor(value) + ";'>" + renderScore(value) + "</span>";
+                }
+              }
+          ]
+      });
+    });
+  </script>
+
+{% endblock javascripts %}

--- a/otterdog/webapp/templates/home/tasks.html
+++ b/otterdog/webapp/templates/home/tasks.html
@@ -22,7 +22,7 @@
       <div class="container-fluid">
         <div class="row mb-2">
           <div class="col-sm-6">
-            <h1>Organizations</h1>
+            <h1>Tasks</h1>
           </div>
           <div class="col-sm-6">
             <ol class="breadcrumb float-sm-right">

--- a/otterdog/webapp/templates/includes/sidebar.html
+++ b/otterdog/webapp/templates/includes/sidebar.html
@@ -56,6 +56,16 @@
           </li>
 
           <li class="nav-item">
+            <a href="/scorecard/checks" class="nav-link {% if 'scorecard' in segments %} active {% endif %}">
+              <i class="nav-icon fas fa-star"></i>
+              <p>
+                OSSF Scorecard
+                <i class="fas nav-icon"></i>
+              </p>
+            </a>
+          </li>
+
+          <li class="nav-item">
             <a href="/query" class="nav-link {% if 'query' in segments %} active {% endif %}">
               <i class="nav-icon fa-brands fa-searchengin"></i>
               <p>

--- a/otterdog/webapp/webhook/github_webhook.py
+++ b/otterdog/webapp/webhook/github_webhook.py
@@ -14,7 +14,6 @@ import hashlib
 import hmac
 import json
 import logging
-from ast import literal_eval
 
 from quart import abort, request
 
@@ -157,7 +156,7 @@ EVENT_FILTER = {"workflow_job": "'{action}' == 'queued'"}
 
 def _log_event(event_type, data) -> bool:
     try:
-        return literal_eval(EVENT_FILTER[event_type].format(**data))
+        return eval(EVENT_FILTER[event_type].format(**data))  # noqa: S307
     except KeyError:
         return True
 


### PR DESCRIPTION
This fixes #345 .

This adds a new blueprint type `scorecard_inegration` to check if scorecard integration is already present. If no a respective workflow is created via PR.

Afterwards, on a regular basis, the scorecard score is retrieved from securityscorecards.dev via their api and displayed in the dashbard (organization / repo view as well):

![image](https://github.com/user-attachments/assets/455807e2-5abf-435b-9d22-9323e457c5f7)
