### PR TITLE
Add support for organization roles and rework security manager setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,23 @@
 
 ### Added
 
+- Added support for organization roles.
 - Added operation `check-token-permissions` to list all granted and missing scopes for the cli token.
 - Added option to specify reviewers for blueprint type `append_configuration`.
 - Added view for currently active remediation PRs for configured blueprints.
 
 ### Changed
 
+- Adapted default template for GitHub organizations to take an additional parameter: project_name.
+- Changed accessing security managers of an organization using the organization roles api. ([#365](https://github.com/eclipse-csi/otterdog/issues/365))
 - Disabled adding automatic help comments for bot users creating a pull request in the config repo.
 - Disabled checking of team membership for bot users creating a pull request in the config repo.
 
 ### Fixed
 
-- Prevent wrapping of long texts when importing the configuration.
+- Fixed displaying changes when settings `squash_merge_commit_title` and `squash_merge_commit_message` were changed at the same time.
+- Prevented setting `private_vulnerability_reporting_enabled` for private repositories.
+- Prevented wrapping of long texts when importing the configuration.
 
 
 ## [0.9.0] - 09/12/2024

--- a/docs/reference/organization/index.md
+++ b/docs/reference/organization/index.md
@@ -4,7 +4,7 @@ This resource represents a GitHub organization with all supported settings and n
 
 === "jsonnet"
     ```jsonnet
-    orgs.newOrg('<github-id>') {
+    orgs.newOrg('<project-name>', '<github-id>') {
         settings+: { ... }, // (1)!
         webhooks+: [ ... ], // (2)!
         secrets+: [ ... ], // (3)!
@@ -30,7 +30,7 @@ This resource represents a GitHub organization with all supported settings and n
 ## Jsonnet Function
 
 ``` jsonnet
-orgs.newOrg('<github-id>') {
+orgs.newOrg('<project-name>', <github-id>') {
   <key>: <value>
 }
 ```
@@ -43,7 +43,7 @@ The configuration of a GitHub Organization is considered to be valid if all nest
 
 === "jsonnet"
     ``` jsonnet
-    orgs.newOrg('adoptium') {
+    orgs.newOrg('adoptium', 'adoptium') {
       settings+: {
         blog: "https://adoptium.net",
         default_repository_permission: "none",

--- a/docs/reference/organization/role.md
+++ b/docs/reference/organization/role.md
@@ -1,0 +1,46 @@
+Definition of a custom `Role` on organization level, the following properties are supported:
+
+| Key           | Value          | Description                                               | Note                                           |
+|---------------|----------------|-----------------------------------------------------------|------------------------------------------------|
+| _name_        | string         | The name of the role                                      |                                                |
+| _description_ | string         | The description of the role                               |                                                |
+| _permissions_ | list[string]   | List of additional permissions                            | TODO                                           |
+| _base_role_   | string         | The system role from which this role inherits permissions | `none`, `read`, `write`, `maintain` or `admin` |
+
+## Jsonnet Function
+
+``` jsonnet
+orgs.newOrgRole('<name>') {
+  <key>: <value>
+}
+```
+
+## Validation rules
+
+- specifying a non-empty list of `permissions` while `base_role` is set to `none` triggers an error
+
+## Example usage
+
+=== "jsonnet"
+    ``` jsonnet
+    orgs.newOrg('OtterdogTest') {
+      ...
+      roles+: [
+        orgs.newOrgRole('security_team') {
+          description: "The security team role",
+          permissions+: [
+            "delete_alerts_code_scanning",
+            "org_review_and_manage_secret_scanning_bypass_requests",
+            "read_code_scanning",
+            "resolve_dependabot_alerts",
+            "resolve_secret_scanning_alerts",
+            "view_dependabot_alerts",
+            "view_secret_scanning_alerts",
+            "write_code_scanning",
+          ],
+          base_role: "read",
+        },
+      ],
+      ...
+    }
+    ```

--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -241,6 +241,14 @@ local newOrgVariable(name) = newRepoVariable(name) {
   selected_repositories: [],
 };
 
+# Function to create a new organization role with default settings.
+local newOrgRole(name) = {
+  name: name,
+  description: "",
+  permissions: [],
+  base_role: "none",
+};
+
 # Function to create a new environment with default settings.
 local newEnvironment(name) = {
   name: name,
@@ -262,7 +270,8 @@ local newCustomProperty(name) = {
 };
 
 # Function to create a new organization with default settings.
-local newOrg(id) = {
+local newOrg(name, id=name) = {
+  project_name: name,
   github_id: id,
   settings: {
     name: null,
@@ -359,6 +368,9 @@ local newOrg(id) = {
     }
   },
 
+  # organization roles
+  roles: [],
+
   # organization secrets
   secrets: [],
 
@@ -385,6 +397,7 @@ local newOrg(id) = {
 
 {
   newOrg:: newOrg,
+  newOrgRole:: newOrgRole,
   newOrgWebhook:: newOrgWebhook,
   newOrgSecret:: newOrgSecret,
   newOrgVariable:: newOrgVariable,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
         - reference/organization/index.md
         - Organization Settings: reference/organization/settings.md
         - Organization Workflow Settings: reference/organization/workflow-settings.md
+        - Organization Role: reference/organization/role.md
         - Organization Webhook: reference/organization/webhook.md
         - Organization Secret: reference/organization/secret.md
         - Organization Variable: reference/organization/variable.md

--- a/otterdog/jsonnet.py
+++ b/otterdog/jsonnet.py
@@ -104,17 +104,17 @@ class JsonnetConfig:
 
         self._initialized = True
 
-    def default_org_config_for_org_id(self, org_id: str) -> dict[str, Any]:
+    def default_org_config_for_org_id(self, project_name: str, org_id: str) -> dict[str, Any]:
         try:
             # load the default settings for the organization
-            snippet = f"(import '{self.template_file}').{self.create_org}('{org_id}')"
+            snippet = f"(import '{self.template_file}').{self.create_org}('{project_name}', '{org_id}')"
             return jsonnet_evaluate_snippet(snippet)
         except RuntimeError as ex:
             raise RuntimeError(f"failed to get default organization config for org '{org_id}': {ex}") from ex
 
     @cached_property
     def default_org_config(self) -> dict[str, Any]:
-        return self.default_org_config_for_org_id("default")
+        return self.default_org_config_for_org_id("default", "default")
 
     @cached_property
     def default_org_role_config(self):

--- a/otterdog/jsonnet.py
+++ b/otterdog/jsonnet.py
@@ -27,6 +27,7 @@ class JsonnetConfig:
     #        rather follow a convention to add new resources more easily.
 
     create_org = "newOrg"
+    create_org_role = "newOrgRole"
     create_org_custom_property = "newCustomProperty"
     create_org_webhook = "newOrgWebhook"
     create_org_secret = "newOrgSecret"
@@ -66,6 +67,7 @@ class JsonnetConfig:
         self._local_only = local_only
 
         self._default_org_config: dict[str, Any] | None = None
+        self._default_org_role_config: dict[str, Any] | None = None
         self._default_org_custom_property_config: dict[str, Any] | None = None
         self._default_org_webhook_config: dict[str, Any] | None = None
         self._default_org_secret_config: dict[str, Any] | None = None
@@ -113,6 +115,16 @@ class JsonnetConfig:
     @cached_property
     def default_org_config(self) -> dict[str, Any]:
         return self.default_org_config_for_org_id("default")
+
+    @cached_property
+    def default_org_role_config(self):
+        try:
+            # load the default org role config
+            org_role_snippet = f"(import '{self.template_file}').{self.create_org_role}('default')"
+            return jsonnet_evaluate_snippet(org_role_snippet)
+        except RuntimeError:
+            _logger.debug("no default org role config found, roles will be skipped")
+            return None
 
     @cached_property
     def default_org_custom_property_config(self):

--- a/otterdog/models/github_organization.py
+++ b/otterdog/models/github_organization.py
@@ -450,8 +450,7 @@ class GitHubOrganization:
         #        for now this is the same for organization settings, but there might be cases where it is different.
         default_settings = jsonnet_config.default_org_config["settings"]
         included_keys = set(default_settings.keys())
-        security_manager_role = default_settings.get("security_manager_role")
-        github_settings = await provider.get_org_settings(github_id, security_manager_role, included_keys, no_web_ui)
+        github_settings = await provider.get_org_settings(github_id, included_keys, no_web_ui)
 
         end = datetime.now()
         _logger.trace(f"organization settings: read complete after {(end - start).total_seconds()}s")

--- a/otterdog/models/organization_role.py
+++ b/otterdog/models/organization_role.py
@@ -1,0 +1,82 @@
+#  *******************************************************************************
+#  Copyright (c) 2023-2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any, cast
+
+from otterdog.models import FailureType, LivePatch, LivePatchType, ValidationContext
+from otterdog.models.role import Role
+from otterdog.utils import is_set_and_valid, unwrap
+
+if TYPE_CHECKING:
+    from otterdog.jsonnet import JsonnetConfig
+    from otterdog.providers.github import GitHubProvider
+
+
+@dataclasses.dataclass
+class OrganizationRole(Role):
+    """
+    Represents a Role defined on organization level.
+    """
+
+    visibility: str
+    selected_repositories: list[str]
+
+    @property
+    def model_object_name(self) -> str:
+        return "org_role"
+
+    def validate(self, context: ValidationContext, parent_object: Any) -> None:
+        from otterdog.models.github_organization import GitHubOrganization
+
+        super().validate(context, parent_object)
+
+        org_settings = cast(GitHubOrganization, context.root_object).settings
+
+        if is_set_and_valid(org_settings.plan):
+            if org_settings.plan != "enterprise":
+                context.add_failure(
+                    FailureType.ERROR,
+                    f"use of organization roles requires an 'enterprise' plan, while this organization is "
+                    f"currently on a '{org_settings.plan}' plan.",
+                )
+
+    def get_jsonnet_template_function(self, jsonnet_config: JsonnetConfig, extend: bool) -> str | None:
+        return f"orgs.{jsonnet_config.create_org_role}"
+
+    @classmethod
+    async def apply_live_patch(
+        cls,
+        patch: LivePatch[OrganizationRole],
+        org_id: str,
+        provider: GitHubProvider,
+    ) -> None:
+        match patch.patch_type:
+            case LivePatchType.ADD:
+                await provider.add_org_custom_role(
+                    org_id,
+                    unwrap(patch.expected_object).name,
+                    await unwrap(patch.expected_object).to_provider_data(org_id, provider),
+                )
+
+            case LivePatchType.REMOVE:
+                await provider.delete_org_custom_role(
+                    org_id,
+                    unwrap(patch.current_object).id,
+                    unwrap(patch.current_object).name,
+                )
+
+            case LivePatchType.CHANGE:
+                await provider.update_org_custom_role(
+                    org_id,
+                    unwrap(patch.current_object).id,
+                    unwrap(patch.current_object).name,
+                    await unwrap(patch.expected_object).to_provider_data(org_id, provider),
+                )

--- a/otterdog/models/organization_role.py
+++ b/otterdog/models/organization_role.py
@@ -9,11 +9,11 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
-from otterdog.models import FailureType, LivePatch, LivePatchType, ValidationContext
+from otterdog.models import LivePatch, LivePatchType
 from otterdog.models.role import Role
-from otterdog.utils import is_set_and_valid, unwrap
+from otterdog.utils import unwrap
 
 if TYPE_CHECKING:
     from otterdog.jsonnet import JsonnetConfig
@@ -32,21 +32,6 @@ class OrganizationRole(Role):
     @property
     def model_object_name(self) -> str:
         return "org_role"
-
-    def validate(self, context: ValidationContext, parent_object: Any) -> None:
-        from otterdog.models.github_organization import GitHubOrganization
-
-        super().validate(context, parent_object)
-
-        org_settings = cast(GitHubOrganization, context.root_object).settings
-
-        if is_set_and_valid(org_settings.plan):
-            if org_settings.plan != "enterprise":
-                context.add_failure(
-                    FailureType.ERROR,
-                    f"use of organization roles requires an 'enterprise' plan, while this organization is "
-                    f"currently on a '{org_settings.plan}' plan.",
-                )
 
     def get_jsonnet_template_function(self, jsonnet_config: JsonnetConfig, extend: bool) -> str | None:
         return f"orgs.{jsonnet_config.create_org_role}"

--- a/otterdog/models/organization_ruleset.py
+++ b/otterdog/models/organization_ruleset.py
@@ -45,16 +45,6 @@ class OrganizationRuleset(Ruleset):
 
         super().validate(context, parent_object)
 
-        org_settings = cast(GitHubOrganization, context.root_object).settings
-
-        if is_set_and_valid(org_settings.plan):
-            if org_settings.plan != "enterprise":
-                context.add_failure(
-                    FailureType.ERROR,
-                    f"use of organization rulesets requires an 'enterprise' plan, while this organization is "
-                    f"currently on a '{org_settings.plan}' plan.",
-                )
-
         repositories = cast(GitHubOrganization, context.root_object).repositories
         all_repo_names = (x.name for x in repositories)
 

--- a/otterdog/models/organization_settings.py
+++ b/otterdog/models/organization_settings.py
@@ -80,7 +80,6 @@ class OrganizationSettings(ModelObject):
     packages_containers_internal: bool
     members_can_change_project_visibility: bool
     security_managers: list[str]
-    security_manager_role: str | None = dataclasses.field(metadata={"model_only": True})
 
     # nested model fields
     workflows: OrganizationWorkflowSettings = dataclasses.field(metadata={"nested_model": True})
@@ -132,17 +131,6 @@ class OrganizationSettings(ModelObject):
         if is_set_and_present(self.custom_properties):
             for custom_property in self.custom_properties:
                 custom_property.validate(context, self)
-
-        if is_set_and_present(self.security_manager_role):
-            from .github_organization import GitHubOrganization
-
-            security_manager_role = cast(GitHubOrganization, parent_object).get_role(self.security_manager_role)
-            if security_manager_role is None:
-                context.add_failure(
-                    FailureType.ERROR,
-                    f"'security_manager_role' has value '{self.security_manager_role}', "
-                    f"while such an organization role is not defined.",
-                )
 
         if is_set_and_present(self.workflows):
             self.workflows.validate(context, self)
@@ -286,10 +274,8 @@ class OrganizationSettings(ModelObject):
             raise ValueError(f"unexpected patch_type '{patch.patch_type}'")
 
         github_settings = await cls.changes_to_provider(org_id, unwrap(patch.changes), provider)
-        security_manager_role = unwrap(patch.expected_object).security_manager_role
 
         await provider.update_org_settings(
             org_id,
-            security_manager_role if is_set_and_present(security_manager_role) else None,
             github_settings,
         )

--- a/otterdog/models/repository.py
+++ b/otterdog/models/repository.py
@@ -756,7 +756,7 @@ class Repository(ModelObject):
         # private repos do not support secret scanning settings, remove them.
         is_private = data.get("private", False)
         if is_private:
-            for security_prop in cls._security_properties:
+            for security_prop in cls._security_properties + cls._additional_security_properties:
                 if security_prop in mapping:
                     mapping.pop(security_prop)
         else:

--- a/otterdog/models/repository.py
+++ b/otterdog/models/repository.py
@@ -1028,14 +1028,17 @@ class Repository(ModelObject):
                 gh_pages_source_path = cast(Repository, coerced_object).gh_pages_source_path
                 modified_repo["gh_pages_source_path"] = Change(gh_pages_source_path, gh_pages_source_path)
 
-            # similar fix as above for squash_merge_commit_title as well
-            if "squash_merge_commit_title" in modified_repo:
+            # similar fix as above for squash_merge_commit_title and squash_merge_commit_message as well
+            squash_merge_commit_title_present = "squash_merge_commit_title" in modified_repo
+            squash_merge_commit_message_present = "squash_merge_commit_message" in modified_repo
+
+            if squash_merge_commit_title_present and not squash_merge_commit_message_present:
                 squash_merge_commit_message = cast(Repository, coerced_object).squash_merge_commit_message
                 modified_repo["squash_merge_commit_message"] = Change(
                     squash_merge_commit_message, squash_merge_commit_message
                 )
 
-            if "squash_merge_commit_message" in modified_repo:
+            if squash_merge_commit_message_present and not squash_merge_commit_title_present:
                 squash_merge_commit_title = cast(Repository, coerced_object).squash_merge_commit_title
                 modified_repo["squash_merge_commit_title"] = Change(
                     squash_merge_commit_title, squash_merge_commit_title

--- a/otterdog/models/role.py
+++ b/otterdog/models/role.py
@@ -1,0 +1,53 @@
+#  *******************************************************************************
+#  Copyright (c) 2023-2024 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+import abc
+import dataclasses
+from typing import Any, TypeVar
+
+from otterdog.models import (
+    FailureType,
+    ModelObject,
+    ValidationContext,
+)
+from otterdog.utils import is_set_and_valid
+
+RT = TypeVar("RT", bound="Role")
+
+
+@dataclasses.dataclass
+class Role(ModelObject, abc.ABC):
+    """
+    Represents a Role.
+    """
+
+    id: int = dataclasses.field(metadata={"external_only": True})
+    source: str = dataclasses.field(metadata={"external_only": True})
+    name: str = dataclasses.field(metadata={"key": True})
+    description: str
+    permissions: list[str]
+    base_role: str
+
+    def validate(self, context: ValidationContext, parent_object: Any) -> None:
+        if is_set_and_valid(self.base_role):
+            if self.base_role not in {"none", "read", "triage", "write", "maintain", "admin"}:
+                context.add_failure(
+                    FailureType.ERROR,
+                    f"{self.get_model_header(parent_object)} has 'base_role' of value '{self.base_role}', "
+                    f"while only values ('none' | 'read' | 'triage' | 'write' | 'maintain' | 'admin') are allowed.",
+                )
+
+        if is_set_and_valid(self.base_role) and is_set_and_valid(self.permissions):
+            if self.base_role == "none" and len(self.permissions) > 0:
+                context.add_failure(
+                    FailureType.ERROR,
+                    f"{self.get_model_header(parent_object)} has 'base_role' of value '{self.base_role}', "
+                    f"and specified additional permissions, which is not allowed.",
+                )

--- a/otterdog/models/role.py
+++ b/otterdog/models/role.py
@@ -12,6 +12,8 @@ import abc
 import dataclasses
 from typing import Any, TypeVar
 
+from jsonbender import F, OptionalS  # type: ignore
+
 from otterdog.models import (
     FailureType,
     ModelObject,
@@ -51,3 +53,16 @@ class Role(ModelObject, abc.ABC):
                     f"{self.get_model_header(parent_object)} has 'base_role' of value '{self.base_role}', "
                     f"and specified additional permissions, which is not allowed.",
                 )
+
+        # TODO: add validation for allowed permissions
+
+    @classmethod
+    def get_mapping_from_provider(cls, org_id: str, data: dict[str, Any]) -> dict[str, Any]:
+        mapping = super().get_mapping_from_provider(org_id, data)
+
+        mapping.update(
+            {
+                "base_role": OptionalS("base_role") >> F(lambda x: x if x is not None else "none"),
+            }
+        )
+        return mapping

--- a/otterdog/operations/diff_operation.py
+++ b/otterdog/operations/diff_operation.py
@@ -172,7 +172,7 @@ class DiffOperation(Operation):
             )
 
         try:
-            current_org = await self.load_current_org(github_id, jsonnet_config)
+            current_org = await self.load_current_org(org_config.name, github_id, jsonnet_config)
         except RuntimeError as e:
             self.printer.print_error(f"failed to load current configuration\n{e!s}")
             return 1
@@ -237,9 +237,11 @@ class DiffOperation(Operation):
     def coerce_current_org(self) -> bool:
         return False
 
-    async def load_current_org(self, github_id: str, jsonnet_config: JsonnetConfig) -> GitHubOrganization:
+    async def load_current_org(
+        self, project_name: str, github_id: str, jsonnet_config: JsonnetConfig
+    ) -> GitHubOrganization:
         return await GitHubOrganization.load_from_provider(
-            github_id, jsonnet_config, self.gh_client, self.no_web_ui, self.concurrency
+            project_name, github_id, jsonnet_config, self.gh_client, self.no_web_ui, self.concurrency
         )
 
     def preprocess_orgs(

--- a/otterdog/operations/import_configuration.py
+++ b/otterdog/operations/import_configuration.py
@@ -88,7 +88,7 @@ class ImportOperation(Operation):
 
             async with GitHubProvider(credentials) as provider:
                 organization = await GitHubOrganization.load_from_provider(
-                    github_id, jsonnet_config, provider, self.no_web_ui
+                    org_config.name, github_id, jsonnet_config, provider, self.no_web_ui
                 )
 
             # copy secrets from existing configuration if it is present.

--- a/otterdog/operations/install_app.py
+++ b/otterdog/operations/install_app.py
@@ -67,9 +67,7 @@ class InstallAppOperation(Operation):
                         self.printer.println("app already installed, skipping.")
                         return 0
 
-                settings = await rest_api.org.get_settings(github_id, {"id"})
-                org_int_id = str(settings["id"])
-
+                org_int_id = str(await rest_api.org.get_id(github_id))
                 await provider.web_client.install_github_app(org_int_id, self.app_slug)
 
             self.printer.println("app installed.")

--- a/otterdog/operations/local_apply.py
+++ b/otterdog/operations/local_apply.py
@@ -68,7 +68,9 @@ class LocalApplyOperation(ApplyOperation):
     def coerce_current_org(self) -> bool:
         return True
 
-    async def load_current_org(self, github_id: str, jsonnet_config: JsonnetConfig) -> GitHubOrganization:
+    async def load_current_org(
+        self, project_name: str, github_id: str, jsonnet_config: JsonnetConfig
+    ) -> GitHubOrganization:
         other_org_file_name = jsonnet_config.org_config_file + self.suffix
 
         if not await ospath.exists(other_org_file_name):

--- a/otterdog/operations/local_plan.py
+++ b/otterdog/operations/local_plan.py
@@ -63,7 +63,9 @@ class LocalPlanOperation(PlanOperation):
     def coerce_current_org(self) -> bool:
         return True
 
-    async def load_current_org(self, github_id: str, jsonnet_config: JsonnetConfig) -> GitHubOrganization:
+    async def load_current_org(
+        self, project_name: str, github_id: str, jsonnet_config: JsonnetConfig
+    ) -> GitHubOrganization:
         other_org_file_name = jsonnet_config.org_config_file + self.suffix
 
         if not await ospath.exists(other_org_file_name):

--- a/otterdog/operations/show_default.py
+++ b/otterdog/operations/show_default.py
@@ -48,12 +48,30 @@ class ShowDefaultOperation(Operation):
             self.printer.level_up()
 
         try:
-            default_org = self.evaluate(jsonnet_config, f"{jsonnet_config.create_org}('<github-id>')")
+            default_org = self.evaluate(jsonnet_config, f"{jsonnet_config.create_org}('<project-name>', '<github-id>')")
             default_org_settings = {"settings": default_org["settings"]}
             self.printer.println()
             self._print_header("Organization Settings")
             self.print_dict(
-                default_org_settings, f"orgs.{jsonnet_config.create_org}('<github-id>') =", "", "red", ":", ","
+                default_org_settings,
+                f"orgs.{jsonnet_config.create_org}('<project-name>', '<github-id>') =",
+                "",
+                "red",
+                ":",
+                ",",
+            )
+            self._print_footer()
+
+            default_org_role = self.evaluate(jsonnet_config, f"{jsonnet_config.create_org_role}('<name>')")
+            self.printer.println()
+            self._print_header("Organization Role")
+            self.print_dict(
+                default_org_role,
+                f"orgs.{jsonnet_config.create_org_role}('<name>') =",
+                "",
+                "black",
+                ":",
+                ",",
             )
             self._print_footer()
 

--- a/otterdog/operations/show_live.py
+++ b/otterdog/operations/show_live.py
@@ -63,7 +63,7 @@ class ShowLiveOperation(Operation):
                     )
 
                 organization = await GitHubOrganization.load_from_provider(
-                    github_id, jsonnet_config, provider, self.no_web_ui
+                    org_config.name, github_id, jsonnet_config, provider, self.no_web_ui
                 )
 
             for model_object, parent_object in organization.get_model_objects():

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -101,13 +101,12 @@ class GitHubProvider:
     async def get_org_settings(
         self,
         org_id: str,
-        security_manager_role: str | None,
         included_keys: set[str],
         no_web_ui: bool,
     ) -> dict[str, Any]:
         # first, get supported settings via the rest api.
         required_rest_keys = {x for x in included_keys if x in _SETTINGS_RESTAPI_KEYS}
-        merged_settings = await self.rest_api.org.get_settings(org_id, security_manager_role, required_rest_keys)
+        merged_settings = await self.rest_api.org.get_settings(org_id, required_rest_keys)
 
         # second, get settings only accessible via the web interface and merge
         # them with the other settings, unless --no-web-ui is specified.
@@ -121,9 +120,7 @@ class GitHubProvider:
 
         return merged_settings
 
-    async def update_org_settings(
-        self, org_id: str, security_manager_role: str | None, settings: dict[str, Any]
-    ) -> None:
+    async def update_org_settings(self, org_id: str, settings: dict[str, Any]) -> None:
         rest_fields = {}
         web_fields = {}
 
@@ -139,7 +136,7 @@ class GitHubProvider:
 
         # update any settings via the rest api
         if len(rest_fields) > 0:
-            await self.rest_api.org.update_settings(org_id, security_manager_role, rest_fields)
+            await self.rest_api.org.update_settings(org_id, rest_fields)
 
         # update any settings via the web interface
         if len(web_fields) > 0:

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -98,10 +98,16 @@ class GitHubProvider:
             author_email,
         )
 
-    async def get_org_settings(self, org_id: str, included_keys: set[str], no_web_ui: bool) -> dict[str, Any]:
+    async def get_org_settings(
+        self,
+        org_id: str,
+        security_manager_role: str | None,
+        included_keys: set[str],
+        no_web_ui: bool,
+    ) -> dict[str, Any]:
         # first, get supported settings via the rest api.
         required_rest_keys = {x for x in included_keys if x in _SETTINGS_RESTAPI_KEYS}
-        merged_settings = await self.rest_api.org.get_settings(org_id, required_rest_keys)
+        merged_settings = await self.rest_api.org.get_settings(org_id, security_manager_role, required_rest_keys)
 
         # second, get settings only accessible via the web interface and merge
         # them with the other settings, unless --no-web-ui is specified.
@@ -115,7 +121,9 @@ class GitHubProvider:
 
         return merged_settings
 
-    async def update_org_settings(self, org_id: str, settings: dict[str, Any]) -> None:
+    async def update_org_settings(
+        self, org_id: str, security_manager_role: str | None, settings: dict[str, Any]
+    ) -> None:
         rest_fields = {}
         web_fields = {}
 
@@ -131,7 +139,7 @@ class GitHubProvider:
 
         # update any settings via the rest api
         if len(rest_fields) > 0:
-            await self.rest_api.org.update_settings(org_id, rest_fields)
+            await self.rest_api.org.update_settings(org_id, security_manager_role, rest_fields)
 
         # update any settings via the web interface
         if len(web_fields) > 0:

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -143,6 +143,18 @@ class GitHubProvider:
     async def update_org_workflow_settings(self, org_id: str, workflow_settings: dict[str, Any]) -> None:
         await self.rest_api.org.update_workflow_settings(org_id, workflow_settings)
 
+    async def get_org_custom_roles(self, org_id: str) -> list[dict[str, Any]]:
+        return await self.rest_api.org.get_custom_roles(org_id)
+
+    async def add_org_custom_role(self, org_id: str, role_name: str, data: dict[str, str]) -> None:
+        await self.rest_api.org.add_custom_role(org_id, role_name, data)
+
+    async def update_org_custom_role(self, org_id: str, role_id: int, role_name: str, data: dict[str, str]) -> None:
+        await self.rest_api.org.update_custom_role(org_id, role_id, role_name, data)
+
+    async def delete_org_custom_role(self, org_id: str, role_id: int, role_name: str) -> None:
+        await self.rest_api.org.delete_custom_role(org_id, role_id, role_name)
+
     async def get_org_custom_properties(self, org_id: str) -> list[dict[str, Any]]:
         return await self.rest_api.org.get_custom_properties(org_id)
 

--- a/otterdog/resources/schemas/org-role.json
+++ b/otterdog/resources/schemas/org-role.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$ref": "role.json",
+  "type": "object",
+  "properties": {},
+
+  "required": [ "name", "permissions", "base_role" ],
+  "unevaluatedProperties": false
+}

--- a/otterdog/resources/schemas/organization.json
+++ b/otterdog/resources/schemas/organization.json
@@ -3,6 +3,7 @@
 
   "type": "object",
   "properties": {
+    "project_name": { "type": "string" },
     "github_id": { "type": "string" },
     "settings": { "$ref": "settings.json" },
     "roles": {
@@ -31,6 +32,6 @@
     }
   },
 
-  "required": [ "settings" ],
+  "required": [ "project_name", "github_id", "settings" ],
   "additionalProperties": false
 }

--- a/otterdog/resources/schemas/organization.json
+++ b/otterdog/resources/schemas/organization.json
@@ -5,6 +5,10 @@
   "properties": {
     "github_id": { "type": "string" },
     "settings": { "$ref": "settings.json" },
+    "roles": {
+      "type": "array",
+      "items": { "$ref": "org-role.json" }
+    },
     "webhooks": {
       "type": "array",
       "items": { "$ref": "webhook.json" }

--- a/otterdog/resources/schemas/role.json
+++ b/otterdog/resources/schemas/role.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "permissions": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "base_role": { "type": "string" }
+  }
+}

--- a/otterdog/resources/schemas/settings.json
+++ b/otterdog/resources/schemas/settings.json
@@ -124,9 +124,6 @@
       "type": "array",
       "items": { "type": "string" }
     },
-    "security_manager_role": {
-      "$ref": "types.json#/$defs/string-or-null"
-    },
     "custom_properties": {
       "type": "array",
       "items": { "$ref": "custom-property.json" }

--- a/otterdog/resources/schemas/settings.json
+++ b/otterdog/resources/schemas/settings.json
@@ -124,6 +124,9 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "security_manager_role": {
+      "$ref": "types.json#/$defs/string-or-null"
+    },
     "custom_properties": {
       "type": "array",
       "items": { "$ref": "custom-property.json" }

--- a/otterdog/webapp/db/service.py
+++ b/otterdog/webapp/db/service.py
@@ -146,12 +146,17 @@ async def update_installations_from_config(
 
                 projects_to_update.add(project_name)
             else:
-                if model.base_template != org_config.base_template:
+                if model.project_name != project_name:
+                    model.project_name = project_name
                     projects_to_update.add(project_name)
 
-                model.project_name = project_name
-                model.config_repo = org_config.config_repo
-                model.base_template = org_config.base_template
+                if model.base_template != org_config.base_template:
+                    model.base_template = org_config.base_template
+                    projects_to_update.add(project_name)
+
+                if model.config_repo != org_config.config_repo:
+                    model.config_repo = org_config.config_repo
+                    projects_to_update.add(project_name)
 
             await session.save(model)
 

--- a/otterdog/webapp/home/routes.py
+++ b/otterdog/webapp/home/routes.py
@@ -29,9 +29,9 @@ from otterdog.webapp.db.service import (
     get_active_installations,
     get_blueprints,
     get_blueprints_status,
-    get_configuration_by_github_id,
     get_configuration_by_project_name,
     get_configurations,
+    get_installation_by_github_id,
     get_installation_by_project_name,
     get_installations,
     get_merged_pull_requests_count,
@@ -174,20 +174,20 @@ async def query():
 
 @blueprint.route("/organizations/<org_name>")
 async def organization(org_name: str):
-    config = await get_configuration_by_github_id(org_name)
-    if config is None:
+    installation = await get_installation_by_github_id(org_name)
+    if installation is None:
         return await render_template("home/page-404.html"), 404
     else:
-        return redirect(url_for(".project", project_name=config.project_name))
+        return redirect(url_for(".project", project_name=installation.project_name))
 
 
 @blueprint.route("/organizations/<org_name>/<path:subpath>")
 async def organization_catch_all_redirect(org_name: str, subpath: str):
-    config = await get_configuration_by_github_id(org_name)
-    if config is None:
+    installation = await get_installation_by_github_id(org_name)
+    if installation is None:
         return await render_template("home/page-404.html"), 404
     else:
-        return redirect(url_for(".project", project_name=config.project_name) + "/" + subpath)
+        return redirect(url_for(".project", project_name=installation.project_name) + "/" + subpath)
 
 
 @blueprint.route("/projects/<project_name>")

--- a/otterdog/webapp/home/routes.py
+++ b/otterdog/webapp/home/routes.py
@@ -300,12 +300,13 @@ async def defaults(project_name: str):
                 jsonnet_config,
                 "org",
                 "GitHub Organization",
-                f"{jsonnet_config.create_org}('<github-id>')",
+                f"{jsonnet_config.create_org}('<project-name>', '<github-id>')",
                 "settings",
             )
         )
 
         elements = [
+            ("org-role", "Organization Role", f"{jsonnet_config.create_org_role}('<name>')"),
             ("org-webhook", "Organization Webhook", f"{jsonnet_config.create_org_webhook}('<url>')"),
             ("org-secret", "Organization Secret", f"{jsonnet_config.create_org_secret}('<name>')"),
             ("org-variable", "Organization Variable", f"{jsonnet_config.create_org_variable}('<name>')"),

--- a/tests/models/resources/test-org/test-org.jsonnet
+++ b/tests/models/resources/test-org/test-org.jsonnet
@@ -1,7 +1,7 @@
 
 local orgs = import 'vendor/test-defaults/test-defaults.libsonnet';
 
-orgs.newOrg('test-org') {
+orgs.newOrg('test-org', 'test-org') {
     settings+: {
       billing_email: "info@test.org",
       blog: "https://www.test.org",

--- a/tests/models/resources/test-org/vendor/test-defaults/test-defaults.libsonnet
+++ b/tests/models/resources/test-org/vendor/test-defaults/test-defaults.libsonnet
@@ -97,7 +97,8 @@ local newBranchProtectionRule(pattern) = {
 };
 
 # Function to create a new organization with default settings.
-local newOrg(id) = {
+local newOrg(name, id) = {
+  project_name: name,
   github_id: id,
   settings: {
     name: null,


### PR DESCRIPTION
This fixes #356 .

The PR introduces support for organization roles and replaces the logic wrt security manager settings.

These setting is deprecated and should be replaced with assigning the security_manager role to teams.

However this has the downside, that with the security manager role teams also have the permissions to alter security configurations for the organization. We would like to avoid that and only allow to configure that via otterdog itself. For that purpose we can define our own custom role that has the same permissions as the predefined security manager role but lacks permissions to alter the security configuration. That seems to be built in the predefined rule.

That is a clean workaround that improves the status quo as all security managers can update the security configuration right now and they should not actually.

After this PR is merged, we can modify the configuration of all projects and add the \<project\>-security team to the list of security managers.