### PR TITLE
chore: ignore otterdog.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,9 @@ site
 .cache/
 .tox
 
-### Ignoring otterdog out directory orgs
+### Ignoring otterdog out directory orgs and conf
 orgs/
+otterdog.json
 
 ### Ignoring data to test
 data


### PR DESCRIPTION
Ignore otterdog config file `otterdog.json` to prevent developers/contributors from adding it while developing.