### PR TITLE
Add explicit check if dynamic versioning plugin is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ifndef POETRY
 endif
 
 	poetry config virtualenvs.in-project true
-	poetry sync --only-root
+	poetry dynamic-versioning show || poetry sync --only-root
 	poetry sync
 	poetry run playwright install firefox
 


### PR DESCRIPTION
This speeds up subsequent `make init` calls.
It first checks if the dynamic versioning plugin is already installed and only then will run `poetry sync --only-root` to install the plugin.