### PR TITLE
Fix inconsistencies wrt import operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed coercion of `has_discussion` property in case the repository is the source of organization discussions.
+- Fixed importing an organization that has multiple custom properties defined.
 - Fixed updating organization teams with `local-apply` operation.
 
 

--- a/otterdog/models/organization_settings.py
+++ b/otterdog/models/organization_settings.py
@@ -219,7 +219,7 @@ class OrganizationSettings(ModelObject):
                 printer.println("custom_properties+: [")
                 printer.level_up()
 
-                for custom_property in self.custom_properties:
+                for _, custom_property in properties_by_name.items():
                     custom_property.to_jsonnet(printer, config, context, False, default_org_custom_property)
 
                 printer.level_down()

--- a/otterdog/models/repository.py
+++ b/otterdog/models/repository.py
@@ -258,6 +258,13 @@ class Repository(ModelObject):
                         if current_property_value == custom_property.default_value:
                             self.custom_properties.pop(custom_property.name)
 
+        if (
+            org_settings.has_discussions
+            and org_settings.discussion_source_repository is not None
+            and org_settings.discussion_source_repository.endswith(f"/{self.name}")
+        ):
+            copy.has_discussions = True
+
         return copy
 
     def validate(self, context: ValidationContext, parent_object: Any) -> None:


### PR DESCRIPTION
This PR fixes 2 small bugs that you hit when importing the current OtterdogTest org:

- do not serialize inherited custom properties
- coerce the has_discussions property of a repo if its the source of organization discussions (that might be a change on GitHub side as this used to work)