### PR TITLE
fix: Adjust Makefile to work on MacOSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ endif
 	poetry config virtualenvs.in-project true
 	poetry dynamic-versioning show || poetry sync --only-root
 	poetry sync
-	poetry run playwright install firefox
+	poetry run python -m playwright install firefox
 
 	test -f $(OTTERDOG_LINK) || ln -s $(OTTERDOG_SCRIPT) $(OTTERDOG_LINK)
 
 test:  ## Run tests
-	poetry run py.test
+	poetry run pytest
 
 clean:  ## Clean the development environment
 	rm -rf .venv


### PR DESCRIPTION
Call playwright using `python -m playwright` as
`poetry run playwright` doesn't appear to work on MacOSX.

py.test didn't work on my system and `pytest` has been the recommended way to invoke pytest since version 3.0 so update the Makefile to use that method.