### PR TITLE
docs: Fix typo in URL

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -41,7 +41,7 @@ Events:
 - Workflow job
 - Workflow run
 
-Configure a webhook using a [smee.io](httsp://smee.io) channel and set up a secret.
+Configure a webhook using a [smee.io](https://smee.io) channel and set up a secret.
 
 Generate and download the private key for the generated GitHub app.
 


### PR DESCRIPTION
The URL has a typo so clicking the link routes to an invalid URL.