### PR TITLE
Skip existing versions when publishing to test.pypi.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -233,4 +233,5 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           attestations: true
+          skip-existing: true
           verbose: true


### PR DESCRIPTION
This might happen due to dynamic versioning and we should ignore these errors.

The whole idea of publishing to test pypi is to make sure the workflow works before doing a real release.