### PR TITLE
fix: Set platform to linux/amd64 for ghproxy

### DIFF
--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -43,6 +43,7 @@ services:
 
   ghproxy:
     image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240923-efb534162
+    platform: linux/amd64
     restart: always
     command:
       - --redis-address=redis:6379


### PR DESCRIPTION
This does not appear to be a multiarch image so hardcode the platform to be linux/amd64 so that it does not fail when run on non-amd64 hardware.

> Error response from daemon: image with reference us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240923-efb534162 was found but its platform (linux/amd64) does not match the specified platform (linux/arm64)