### PR TITLE
Add command to check the validation and sync status of orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  - Properly escape string values when passing them to a rich Console. ([#440](https://github.com/eclipse-csi/otterdog/issues/440))
  - Add support for marking organizations as archived and to ignore them. ([#463](https://github.com/eclipse-csi/otterdog/issues/463))
+ - Add new check-status CLI command. This outputs a json file of with sync, validation, and archival status of organizations. ([#457](https://github.com/eclipse-csi/otterdog/issues/457))
 
 ## [1.0.4] - 22/05/2025
 

--- a/otterdog/cli.py
+++ b/otterdog/cli.py
@@ -463,6 +463,45 @@ def plan(organizations: list[str], no_web_ui, repo_filter, update_webhooks, upda
     )
 
 
+@cli.command(cls=StdCommand, short_help="Check for sync with live configuration on GitHub.")
+@click.option(
+    "-n",
+    "--no-web-ui",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="skip settings retrieved via web ui",
+)
+@click.option(
+    "-r",
+    "--repo-filter",
+    show_default=True,
+    default="*",
+    help="a valid shell pattern to match repository names to be included",
+)
+@click.option(
+    "-j",
+    "--json",
+    type=click.Path(file_okay=True, dir_okay=False, writable=False, readable=True, allow_dash=True),
+    help="a file to write the status as JSON output",
+)
+def check_status(organizations: list[str], no_web_ui, repo_filter, json):
+    """
+    Check the status of current configuration (validity and whether it is in sync with the GitHub live configuration).
+    Output JSON with the status of each organization.
+    """
+    from otterdog.operations.check_status import CheckStatusOperation
+
+    _execute_operation(
+        organizations,
+        CheckStatusOperation(
+            no_web_ui=no_web_ui,
+            repo_filter=repo_filter,
+            output_json=json,
+        ),
+    )
+
+
 @cli.command(cls=StdCommand, short_help="Show changes to another local configuration.")
 @click.option(
     "-s",

--- a/otterdog/operations/apply.py
+++ b/otterdog/operations/apply.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from otterdog.models import ModelObject
 
     from .diff_operation import DiffStatus
+    from .validate import ValidationStatus
 
 
 class ApplyOperation(PlanOperation):
@@ -92,7 +93,9 @@ class ApplyOperation(PlanOperation):
         )
         return modified
 
-    async def handle_finish(self, org_id: str, diff_status: DiffStatus, patches: list[LivePatch]) -> int:
+    async def handle_finish(
+        self, org_id: str, diff_status: DiffStatus, validation_status: ValidationStatus, patches: list[LivePatch]
+    ) -> int:
         self.printer.println()
 
         if diff_status.total_changes(self._delete_resources) == 0:

--- a/otterdog/operations/check_status.py
+++ b/otterdog/operations/check_status.py
@@ -1,0 +1,111 @@
+#  *******************************************************************************
+#  Copyright (c) 2023-2025 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+from json import dumps as json_dumps
+from typing import TYPE_CHECKING
+
+from .diff_operation import DiffOperation, DiffStatus
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from otterdog.models import LivePatch, ModelObject
+    from otterdog.utils import Change
+
+    from .validate import ValidationStatus
+
+
+class CheckStatusOperation(DiffOperation):
+    """
+    Check the status of current configuration (validity and wether it is in sync with the GitHub live configuration)
+    """
+
+    def __init__(
+        self,
+        no_web_ui: bool,
+        repo_filter: str,
+        output_json: str | None = None,
+    ):
+        super().__init__(no_web_ui, repo_filter, False, False, "*")
+        self.orgs_status: list[Any] = []
+        self.output_json = output_json
+
+    def pre_execute(self) -> None: ...
+
+    def post_execute(self) -> None:
+        if self.output_json and self.orgs_status:
+            with open(self.output_json, "w", encoding="utf-8") as f:
+                f.write(json_dumps(self.orgs_status, indent=2))
+
+    def resolve_secrets(self) -> bool:
+        return False
+
+    async def handle_finish(
+        self, org_id: str, diff_status: DiffStatus, validation_status: ValidationStatus, patches: list[LivePatch]
+    ) -> int:
+        is_archived = await self.gh_client.rest_api.org.is_archived(org_id)
+        org_status = {
+            "org_id": org_id,
+            "is_archived": is_archived,
+            "validation_status": {
+                "is_valid": validation_status.total_notices() == 0,
+                "infos": validation_status.infos,
+                "warnings": validation_status.warnings,
+                "errors": validation_status.errors,
+            },
+            "sync_status": {
+                "in_sync": validation_status.total_notices() == 0 and not patches,
+                "additions": diff_status.additions,
+                "changes": diff_status.differences,
+                "deletions": diff_status.deletions,
+            },
+        }
+        self.orgs_status.append(org_status)
+
+        self.printer.println(
+            f"Archived: {is_archived}\n"
+            f"Validation status: {validation_status.total_notices() == 0}\n"
+            f"Synchronization status: {validation_status.total_notices() == 0 and not patches}"
+        )
+
+        return 0
+
+    def handle_validation_status(self, validation_status: ValidationStatus) -> bool:
+        return validation_status.errors == 0
+
+    def handle_add_object(
+        self,
+        org_id: str,
+        model_object: ModelObject,
+        parent_object: ModelObject | None = None,
+    ) -> None: ...
+
+    def handle_delete_object(
+        self,
+        org_id: str,
+        model_object: ModelObject,
+        parent_object: ModelObject | None = None,
+    ) -> None: ...
+
+    def handle_modified_object(
+        self,
+        org_id: str,
+        modified_object: dict[str, Change[Any]],
+        forced_update: bool,
+        current_object: ModelObject,
+        expected_object: ModelObject,
+        parent_object: ModelObject | None = None,
+    ) -> int:
+        settings_to_change = 0
+        for k, _v in modified_object.items():
+            if not current_object.is_read_only_key(k):
+                settings_to_change += 1
+
+        return settings_to_change

--- a/otterdog/operations/validate.py
+++ b/otterdog/operations/validate.py
@@ -108,7 +108,6 @@ class ValidateOperation(Operation):
         organization: GitHubOrganization,
         jsonnet_config: JsonnetConfig,
         provider: GitHubProvider,
-        print_status: bool = True,
     ) -> ValidationStatus:
         if organization.secrets_resolved is True:
             raise RuntimeError("validation requires an unresolved model.")
@@ -120,18 +119,15 @@ class ValidateOperation(Operation):
         for failure_type, message in context.validation_failures:
             match failure_type:
                 case FailureType.INFO:
-                    if print_status:
-                        self.printer.print_info(message)
+                    self.printer.print_info(message)
                     validation_status.infos += 1
 
                 case FailureType.WARNING:
-                    if print_status:
-                        self.printer.print_warn(message)
+                    self.printer.print_warn(message)
                     validation_status.warnings += 1
 
                 case FailureType.ERROR:
-                    if print_status:
-                        self.printer.print_error(message)
+                    self.printer.print_error(message)
                     validation_status.errors += 1
 
         return validation_status

--- a/otterdog/providers/github/rest/org_client.py
+++ b/otterdog/providers/github/rest/org_client.py
@@ -30,6 +30,15 @@ class OrgClient(RestClient):
         except GitHubException as ex:
             raise RuntimeError(f"failed retrieving id for org '{org_id}':\n{ex}") from ex
 
+    async def is_archived(self, org_id: str) -> bool:
+        _logger.debug("checking if org '%s' is archived", org_id)
+
+        try:
+            settings = await self.requester.request_json("GET", f"/orgs/{org_id}")
+            return settings["archived_at"] is not None
+        except GitHubException as ex:
+            raise RuntimeError(f"failed retrieving archived_at for org '{org_id}':\n{ex}") from ex
+
     async def get_settings(self, org_id: str, included_keys: set[str]) -> dict[str, Any]:
         _logger.debug("retrieving settings for org '%s'", org_id)
 

--- a/otterdog/webapp/tasks/check_sync.py
+++ b/otterdog/webapp/tasks/check_sync.py
@@ -37,6 +37,7 @@ from otterdog.webapp.webhook.github_models import PullRequest
 if TYPE_CHECKING:
     from otterdog.models import LivePatch
     from otterdog.operations.diff_operation import DiffStatus
+    from otterdog.operations.validate import ValidationStatus
 
 
 @dataclass(repr=False)
@@ -162,7 +163,9 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
 
             config_in_sync = True
 
-            def sync_callback(org_id: str, diff_status: DiffStatus, patches: list[LivePatch]):
+            def sync_callback(
+                org_id: str, diff_status: DiffStatus, validation_status: ValidationStatus, patches: list[LivePatch]
+            ):
                 nonlocal config_in_sync
                 config_in_sync = diff_status.total_changes(True) == 0
 

--- a/otterdog/webapp/tasks/validate_pull_request.py
+++ b/otterdog/webapp/tasks/validate_pull_request.py
@@ -31,6 +31,7 @@ from otterdog.webapp.webhook.github_models import PullRequest, Repository
 
 if TYPE_CHECKING:
     from otterdog.operations.diff_operation import DiffStatus
+    from otterdog.operations.validate import ValidationStatus
     from otterdog.providers.github.rest import RestApi
 
 
@@ -150,7 +151,9 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
                 printer = IndentingPrinter(output, log_level=self.log_level, output_for_github=True)
                 operation = LocalPlanOperation("-BASE", "*", False, False, "")
 
-                def callback(org_id: str, diff_status: DiffStatus, patches: list[LivePatch]):
+                def callback(
+                    org_id: str, diff_status: DiffStatus, validation_status: ValidationStatus, patches: list[LivePatch]
+                ):
                     validation_result.requires_secrets = any(x.requires_secrets() for x in patches)
                     validation_result.requires_web_ui = any(x.requires_web_ui() for x in patches)
 


### PR DESCRIPTION
The output is in json format:

```
otterdog check-status A B C
[
  {
    "org_id": "A",
    "validation_status": {
      "is_valid": true,
      "infos": 0,
      "warnings": 0,
      "errors": 0
    },
    "sync_status": {
      "in_sync": true,
      "additions": 0,
      "changes": 0,
      "deletions": 0
    }
  },
  {
    "org_id": "B",
    "validation_status": {
      "is_valid": false,
      "infos": 0,
      "warnings": 0,
      "errors": 2
    },
    "sync_status": {
      "in_sync": false,
      "additions": 0,
      "changes": 0,
      "deletions": 0
    }
  },
  {
    "org_id": "C",
    "validation_status": {
      "is_valid": true,
      "infos": 47,
      "warnings": 0,
      "errors": 0
    },
    "sync_status": {
      "in_sync": false,
      "additions": 0,
      "changes": 1,
      "deletions": 0
    }
  }
]
```