### PR TITLE
change: make the sync-check task succeed in any case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [1.0.5] - unreleased
 
+### Changed
+
+ - Make the `sync-check` always succeed to not prevent PRs from being merged due to unrelated changes in the live settings.
+
 ### Fixed
 
  - Properly escape string values when passing them to a rich Console. ([#440](https://github.com/eclipse-csi/otterdog/issues/440))

--- a/otterdog/webapp/tasks/check_sync.py
+++ b/otterdog/webapp/tasks/check_sync.py
@@ -238,7 +238,12 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
             status = "success"
         else:
             desc = "otterdog sync check failed, check comment history"
-            status = "error"
+            # even if the sync check failed, mark the status check with success
+            # to not prevent the PR from being merged
+            # the sync check is mainly for informational purposes since the apply task
+            # will run a local-apply operation only update the changed settings and thus
+            # not touching live settings that are different to the configuration.
+            status = "success"
 
         rest_api = await self.rest_api
         await rest_api.commit.create_commit_status(


### PR DESCRIPTION
As discussed:

Right now, if there is any deviation found between configuration and live settings when raising a PR, the auto-merging is basically blocked.

The sync check nowadays is mainly for informational purposes and gives you an indication that your configuration is out of sync and should be updated to reflect the live settings. However, when merging a PR, the changes are applied with the `local-apply` operation, which calculates the changes based purely on the now merged configuration compared to the previous HEAD one. Thus existing deviations in the live settings will not be overwritten and a merge should be allowed.

The positive side-effect is also that people can then raise PRs to align the configuration to the live settings and actually merge this PR without intervention from EF staff.

@mbarbero @kairoaraujo 