### PR TITLE
Fix pattern example + add more info on syntax

### DIFF
--- a/docs/reference/organization/repository/branch-or-tag.md
+++ b/docs/reference/organization/repository/branch-or-tag.md
@@ -1,10 +1,10 @@
 A BranchOrTag represents either a branch or tag pattern to use within an [Environment](environment.md).
 The following format is used to distinguish between tags and branches:
 
-| Type   | Format          | Example       |
-|--------|-----------------|---------------|
-| Branch | `<pattern>`     | `main`        |
-| Tag    | `tag:<pattern>` | `tag:v[0-9]*` |
+| Type   | Format          | Example                                 |
+|--------|-----------------|-----------------------------------------|
+| Branch | `<pattern>`     | `main`                                  |
+| Tag    | `tag:<pattern>` | `tag:v[0-9]*`, `tag:v[0-9].[0-9].[0-9]` |
 
 For more information about the pattern matching syntax, see the
 [Ruby File.fnmatch documentation](https://ruby-doc.org/current/File.html#method-c-fnmatch).


### PR DESCRIPTION
While making some changes for Eclipse Ankaios we stumbled across a typo in the ottergod documentation.

`v[0-9].[0-9].[0.9]` would not match patch versions with 2, 3, etc., as there is a dot and not a dash in the list.

As the previous example would also only match versions with single digit major, minor or patch numbers and it is not possible to define a proper pattern in the used syntax for a general purpose example, it would be easier to match against a `v[0-9]*` as suggested here.