### PR TITLE
chore: add support for rust code scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.1.1] - unreleased
+
+### Added
+
+- Added support for rust code scanning
+
 ## [1.1.0] - 04/09/2025
 
 ### Added

--- a/otterdog/models/repository.py
+++ b/otterdog/models/repository.py
@@ -185,6 +185,7 @@ class Repository(ModelObject):
         "python",
         "ruby",
         "swift",
+        "rust",
     }
 
     @property


### PR DESCRIPTION
Rust is now as public preview by GitHub