### PR TITLE
fix: update npm dependencies after admin-lte update

### DIFF
--- a/otterdog/webapp/static/package-lock.json
+++ b/otterdog/webapp/static/package-lock.json
@@ -9,16 +9,22 @@
       "version": "0.0.1",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.1",
-        "admin-lte": "^4.0.0-rc3",
+        "admin-lte": "^4.0.0-rc4",
         "bootstrap": "^4.6.2",
         "chart.js": "^4.4.2",
         "codemirror": "^5.65.16",
         "codemirror-graphql": "^2.0.10",
         "codemirror-mode-jsonnet": "^1.0.0",
+        "datatables.net": "^2.3.4",
+        "datatables.net-bs4": "^2.3.4",
+        "datatables.net-responsive": "^3.0.7",
+        "datatables.net-responsive-bs4": "^3.0.7",
         "highlight.js": "^11.10.0",
         "jquery": "^3.7.1",
         "jquery-ui-dist": "^1.13.2",
-        "marked": "^15.0.0"
+        "jsgrid": "^1.5.3",
+        "marked": "^15.0.0",
+        "moment": "^2.30.1"
       },
       "devDependencies": {
         "husky": "^9.0.11",
@@ -856,9 +862,9 @@
       }
     },
     "node_modules/admin-lte": {
-      "version": "4.0.0-rc3",
-      "resolved": "https://registry.npmjs.org/admin-lte/-/admin-lte-4.0.0-rc3.tgz",
-      "integrity": "sha512-BKEGJknLiNW/l++6tjO9YIy2x6il4y/S977cSaRfi+wadZF3xe7U+vDR8q2H99CVC49VmPqRwb36hiyEVmBQTw==",
+      "version": "4.0.0-rc4",
+      "resolved": "https://registry.npmjs.org/admin-lte/-/admin-lte-4.0.0-rc4.tgz",
+      "integrity": "sha512-k+ILDKHO6Tn77nMqvQ+wmQoes0Eky/s23jp2P07nUbbILk+7RMnLkCW2jFgiXaO9eFQ2fhmes0LAXJmQbdfpjA==",
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -975,6 +981,46 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/codemirror-mode-jsonnet/-/codemirror-mode-jsonnet-1.0.0.tgz",
       "integrity": "sha512-B58agnWFYAjxJgLvxGl71K5zMz0+yKjNIS5f4/AFdHYg7ut95Z/iHh5jXVKCXy8xZQ6Xp9jGGoowINiLXskkkA=="
+    },
+    "node_modules/datatables.net": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.3.4.tgz",
+      "integrity": "sha512-fKuRlrBIdpAl2uIFgl9enKecHB41QmFd/2nN9LBbOvItV/JalAxLcyqdZXex7wX4ZXjnJQEnv6xeS9veOpKzSw==",
+      "license": "MIT",
+      "dependencies": {
+        "jquery": ">=1.7"
+      }
+    },
+    "node_modules/datatables.net-bs4": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-2.3.4.tgz",
+      "integrity": "sha512-uWcVr8OQeqK6gWIbZDIebm+gtBT3KsDynKduZSUHM8hL3TIsWAyYzb7LxVHSpVRy9iqRqIvpVDEw0tx/IrnxrA==",
+      "license": "MIT",
+      "dependencies": {
+        "datatables.net": "2.3.4",
+        "jquery": ">=1.7"
+      }
+    },
+    "node_modules/datatables.net-responsive": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/datatables.net-responsive/-/datatables.net-responsive-3.0.7.tgz",
+      "integrity": "sha512-MngWU41M1LDDMjKFJ3rAHc4Zb3QhOysDTh+TfKE1ycrh5dpnKa1vobw2MKMMbvbx4q05OXZY9jtLSPIkaJRsuw==",
+      "license": "MIT",
+      "dependencies": {
+        "datatables.net": "^2",
+        "jquery": ">=1.7"
+      }
+    },
+    "node_modules/datatables.net-responsive-bs4": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/datatables.net-responsive-bs4/-/datatables.net-responsive-bs4-3.0.7.tgz",
+      "integrity": "sha512-N5TDe0A31J1pEIpcd1GlU70deHUUeqbuLbFr6LUJ8Q3HXiD9bjyrYiuev8G4viFtRCNHMcrUCJnSRHu5ZtuK1A==",
+      "license": "MIT",
+      "dependencies": {
+        "datatables.net-bs4": "^2",
+        "datatables.net-responsive": "3.0.7",
+        "jquery": ">=1.7"
+      }
     },
     "node_modules/debounce-promise": {
       "version": "3.1.2",
@@ -1194,6 +1240,12 @@
         "jquery": ">=1.8.0 <4.0.0"
       }
     },
+    "node_modules/jsgrid": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/jsgrid/-/jsgrid-1.5.3.tgz",
+      "integrity": "sha512-/BJgQp7gZe8o/VgNelwXc21jHc9HN+l7WPOkBhC9b9jPXFtOrU9ftNLPVBmKYCNlIulAbGTW8SDJI0mpw7uWxQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1237,6 +1289,15 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/nanoid": {

--- a/otterdog/webapp/static/package.json
+++ b/otterdog/webapp/static/package.json
@@ -15,16 +15,22 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.5.1",
-    "admin-lte": "^4.0.0-rc3",
+    "admin-lte": "^4.0.0-rc4",
     "bootstrap": "^4.6.2",
     "chart.js": "^4.4.2",
     "codemirror": "^5.65.16",
     "codemirror-graphql": "^2.0.10",
     "codemirror-mode-jsonnet": "^1.0.0",
+    "datatables.net": "^2.3.4",
+    "datatables.net-bs4": "^2.3.4",
+    "datatables.net-responsive": "^3.0.7",
+    "datatables.net-responsive-bs4": "^3.0.7",
+    "highlight.js": "^11.10.0",
     "jquery": "^3.7.1",
     "jquery-ui-dist": "^1.13.2",
-    "highlight.js": "^11.10.0",
-    "marked": "^15.0.0"
+    "jsgrid": "^1.5.3",
+    "marked": "^15.0.0",
+    "moment": "^2.30.1"
   },
   "overrides": {
     "summernote": "^0.9.1",

--- a/otterdog/webapp/static/vite.config.js
+++ b/otterdog/webapp/static/vite.config.js
@@ -45,7 +45,7 @@ export default defineConfig({
                     dest: outVendorDir + "/moment"
                 },
                 {
-                    src: "../node_modules/datatables.net/js/jquery.dataTables.min.js",
+                    src: "../node_modules/datatables.net/js/dataTables.min.js",
                     dest: outVendorDir + "/datatables"
                 },
                 {


### PR DESCRIPTION
Updated admin-lte from 3.2.0 to 4.0.0-rc3 was done to remove pdfmake vulnerability

- Added missing dependencies (jsgrid, moment, datatables packages) that were previously included in admin-lte 3.x but removed in 4.x
- Fixed DataTables.net path in vite.config.js: changed from 'jquery.dataTables.min.js' to 'dataTables.min.js' to match the new naming convention in DataTables.net 2.x (the jquery prefix was removed in v2)

This change is necessary because DataTables.net changed their file naming between major versions when dropping the jQuery-specific naming.