### PR TITLE
Fix newlines in list-advisories csv output

### DIFF
--- a/otterdog/operations/list_advisories.py
+++ b/otterdog/operations/list_advisories.py
@@ -58,7 +58,7 @@ class ListAdvisoriesOperation(Operation):
         if is_info_enabled():
             self.printer.println(f"Listing {self.states} repository security advisories:")
         if not self.details:
-            self.printer.println(",".join(self.CSV_FIELDS))
+            self.printer.println(",".join(self.CSV_FIELDS), soft_wrap=True)
 
     def post_execute(self) -> None:
         pass
@@ -116,7 +116,7 @@ class ListAdvisoriesOperation(Operation):
                     ), f"CSV fields mismatch! Expected {list(self.CSV_FIELDS)}, got {list(formatted_values.keys())}"
 
                     csv_values = [f'"{formatted_values[field]}"' for field in self.CSV_FIELDS]
-                    self.printer.println(",".join(csv_values))
+                    self.printer.println(",".join(csv_values), soft_wrap=True)
                 else:
                     self.print_dict(advisory, f"advisory['{advisory['ghsa_id']}']", "", "black")
 

--- a/otterdog/utils.py
+++ b/otterdog/utils.py
@@ -290,20 +290,20 @@ class IndentingPrinter:
     def current_indentation(self) -> str:
         return self._initial_offset + " " * (self._level * self._spaces_per_level)
 
-    def print(self, text: str = "", highlight: bool = False) -> None:
+    def print(self, text: str = "", highlight: bool = False, soft_wrap: bool = False) -> None:
         lines = text.splitlines(keepends=True)
         if len(lines) > 0:
             for line in lines:
                 self._print_indentation()
 
                 if line.endswith("\n"):
-                    self._console.print(line[:-1], end="", highlight=highlight)
+                    self._console.print(line[:-1], end="", highlight=highlight, soft_wrap=soft_wrap)
                     self.print_line_break()
                 else:
-                    self._console.print(line, end="", highlight=highlight)
+                    self._console.print(line, end="", highlight=highlight, soft_wrap=soft_wrap)
 
-    def println(self, text: str = "", highlight: bool = False) -> None:
-        self.print(text, highlight=highlight)
+    def println(self, text: str = "", highlight: bool = False, soft_wrap: bool = False) -> None:
+        self.print(text, highlight=highlight, soft_wrap=soft_wrap)
         self.print_line_break()
 
     def print_line_break(self) -> None:

--- a/tests/operations/test_list_advisories.py
+++ b/tests/operations/test_list_advisories.py
@@ -13,6 +13,17 @@ from otterdog.operations.list_advisories import ListAdvisoriesOperation
 
 
 class TestListAdvisoriesOperation:
+    def test_pre_execute(self):
+        operation = ListAdvisoriesOperation(states=["published"], details=False)
+        operation.printer = pretend.stub(println=pretend.call_recorder(lambda msg, **kwargs: None))
+
+        operation.pre_execute()
+
+        assert len(operation.printer.println.calls) == 1
+        call = operation.printer.println.calls[0]
+        assert "soft_wrap" in call.kwargs
+        assert call.kwargs["soft_wrap"] is True
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "advisory_data,expected_values",
@@ -74,7 +85,7 @@ class TestListAdvisoriesOperation:
         test_advisory = {**base_advisory, **advisory_data}
 
         operation.printer = pretend.stub(
-            println=pretend.call_recorder(lambda msg: None),
+            println=pretend.call_recorder(lambda msg, **kwargs: None),
             level_up=lambda: None,
             level_down=lambda: None,
         )
@@ -93,6 +104,10 @@ class TestListAdvisoriesOperation:
 
         assert result == 0
         assert len(operation.printer.println.calls) == 1
+
+        call = operation.printer.println.calls[0]
+        assert "soft_wrap" in call.kwargs
+        assert call.kwargs["soft_wrap"] is True
 
         csv_output = operation.printer.println.calls[0].args[0]
 
@@ -135,7 +150,7 @@ class TestListAdvisoriesOperation:
         operation = ListAdvisoriesOperation(states=states, details=False)
 
         operation.printer = pretend.stub(
-            println=pretend.call_recorder(lambda msg: None),
+            println=pretend.call_recorder(lambda msg, **kwargs: None),
             level_up=lambda: None,
             level_down=lambda: None,
         )


### PR DESCRIPTION
fixes #523

* Add `soft_wrap` parameter with backwards-compatible default to `print()` and `println()` methods of `IndentingPrinter`
* Apply `soft_wrap=True` to CSV output in list-advisories
* Add tests
  * test wrapping behavior of print/println in test_utils
  * test parameter passing in test_list_advisories