### PR TITLE
fix: totp / 2fa seed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The item stored in bitwarden needs to contain the following information (a sampl
   "login": {
     "username": "<github username>",
     "password": "<github password>",
-    "totp": "<github TOTP text code>"
+    "totp": "<2FA TOTP seed>"
   }
 }
 ```
@@ -180,7 +180,7 @@ Mandatory items:
 * Field with name "api_token_admin" and as value the GitHub token to access the organization
 * __login.username__ of a user that can access the organization with enabled 2FA
 * __login.password__ the password of that user
-* __login.totp__ the TOTP text code
+* __login.totp__ the 2FA TOTP seed
 
 #### Pass
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -102,7 +102,7 @@ The item stored in bitwarden needs to contain the following information (a sampl
   "login": {
     "username": "<github username>",
     "password": "<github password>",
-    "totp": "<github TOTP text code>"
+    "totp": "<github 2FA TOTP seed>"
   }
 }
 ```
@@ -112,7 +112,7 @@ Mandatory items:
 * Field with name "api_token_admin" and as value the GitHub token to access the organization
 * __login.username__ of a user that can access the organization with enabled 2FA
 * __login.password__ the password of that user
-* __login.totp__ the TOTP text code
+* __login.totp__ the 2FA TOTP seed
 
 #### Pass
 

--- a/otterdog/credentials/__init__.py
+++ b/otterdog/credentials/__init__.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import binascii
 import dataclasses
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol
@@ -58,7 +59,11 @@ class Credentials:
             raise RuntimeError("totp_secret not available")
 
         while True:
-            totp = mintotp.totp(self._totp_secret)
+            try:
+                totp = mintotp.totp(self._totp_secret)
+            except binascii.Error as e:
+                raise RuntimeError(f"the 2FA TOTP seed is not valid: {e}") from e
+
             _logger.trace("generated totp '%s'", totp)
 
             if self._last_totp is None or totp != self._last_totp:


### PR DESCRIPTION
As far as I understand the code requires the 2FA secret = totp secret. Not the totp.
The documentation was somewhat inconsistent.

Note that the bitwarden field is still named "totp". I did not touch that.