### PR TITLE
feat: team-sync

### DIFF
--- a/otterdog/models/github_organization.py
+++ b/otterdog/models/github_organization.py
@@ -581,8 +581,18 @@ class GitHubOrganization:
                         and default_org.get_team(team_name) is None
                     ):
                         continue
-                    team_members = await provider.get_org_team_members(github_id, team_slug)
-                    team["members"] = team_members
+
+                    # Team-Sync is only available for Enterprise organizations
+                    if org.settings.plan == "enterprise":
+                        team_sync = await provider.get_org_team_sync_mapping(github_id, team_slug)
+                    else:
+                        team_sync = None
+
+                    if team_sync:
+                        team["team_sync"] = team_sync
+                    else:
+                        team_members = await provider.get_org_team_members(github_id, team_slug)
+                        team["members"] = team_members
                     org.add_team(Team.from_provider_data(github_id, team))
             else:
                 _logger.debug("not reading teams, no default config available")

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from importlib_resources import files
 
 from otterdog import resources
+from otterdog.providers.github.rest import TeamSyncMapping
 from otterdog.utils import get_logger, is_ghsa_repo, is_set_and_present
 
 if TYPE_CHECKING:
@@ -162,6 +163,9 @@ class GitHubProvider:
 
     async def get_org_teams(self, org_id: str) -> list[dict[str, Any]]:
         return await self.rest_api.team.get_teams(org_id)
+
+    async def get_org_team_sync_mapping(self, org_id: str, team_slug: str) -> list[TeamSyncMapping]:
+        return await self.rest_api.team.get_team_sync_mapping(org_id, team_slug)
 
     async def get_org_team_members(self, org_id: str, team_slug: str) -> list[dict[str, Any]]:
         return await self.rest_api.team.get_team_members(org_id, team_slug)

--- a/otterdog/providers/github/rest/__init__.py
+++ b/otterdog/providers/github/rest/__init__.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from functools import cached_property
 from typing import TYPE_CHECKING
@@ -166,3 +167,11 @@ def encrypt_value(public_key: str, secret_value: str) -> str:
 
 def parse_iso_date_string(date: str) -> datetime:
     return datetime.fromisoformat(date)
+
+@dataclass
+class TeamSyncMapping:
+    group_id: str
+    group_name: str
+    group_description: str
+    status: str | None
+    synced_at: str | None

--- a/otterdog/resources/schemas/team.json
+++ b/otterdog/resources/schemas/team.json
@@ -9,6 +9,19 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "team_sync": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "group_id": { "type": "string" },
+          "group_name": { "type": "string" },
+          "group_description": { "type": "string" }
+        },
+        "required": [ "group_id", "group_name", "group_description" ],
+        "additionalProperties": false
+      }
+    },
     "privacy": { "type": "string" },
     "notifications": { "type": "boolean" },
     "skip_members": { "type": "boolean" },


### PR DESCRIPTION
This is faaar from working. I still need to understand some basic concepts in otterdog.
I'm just using this to collect some feedback, whether such an addition to otterdog would be wanted.

Use-Case: Our GitHub teams are mapped to an IdP provider for centralized permission management. I need to either set `skip_members` on all our teams and use an additional script (currently Pulumi with Terraform under the hood), or I can extend otterdog to handle team-sync directly.

Note that adding team-sync and team-to-repo permission settings will slow down otterdog commands potentially significantly.