### PR TITLE
Exclude in-sync from checks if a PR can be automerged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Support for config files written in jsonnet ([#542](https://github.com/eclipse-csi/otterdog/pull/542))
 
+### Changed
+
+ - Do not take `in-sync` into account anymore when deciding if a PR can be automerged.
+
 ## [1.1.1] - 21/11/2025
 
 ### Added

--- a/otterdog/webapp/db/models.py
+++ b/otterdog/webapp/db/models.py
@@ -112,7 +112,10 @@ class PullRequestModel(Model):
     def can_be_automerged(self) -> bool:
         return (
             self.valid is True
-            and self.in_sync is True
+            # do not explicitly require that the config is in sync
+            # only changes to the latest checked in config are applied
+            # this allows projects to update the config even if its out-of-sync.
+            # and self.in_sync is True
             and self.supports_auto_merge is True
             and (self.author_can_auto_merge is True or self.has_required_approvals is True)
         )


### PR DESCRIPTION
We changed the check-sync task to never fail, but a PR was only automerged if the `in-sync` flag is also enabled.

This was an oversight, as it would still not allow projects to automerge and they cant fix out-of-sync errors themselves.

With this change, they should now be able to automerge even if there are sync errors.