### PR TITLE
Update link to Contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please read the [Contributing](https://otterdog.readthedocs.io/en/latest/contributing/) guidelines in the documentation site.
+Please read the [Contributing](https://otterdog.readthedocs.io/en/latest/developing_otterdog/) guidelines on the documentation site.


### PR DESCRIPTION
This link is broken after the updates to the contributing section in the documentation.