### PR TITLE
Simplify live patch generation handling

### DIFF
--- a/otterdog/operations/diff_operation.py
+++ b/otterdog/operations/diff_operation.py
@@ -209,7 +209,8 @@ class DiffOperation(Operation):
                 current_org.settings if self.coerce_current_org() else None,
                 expected_org.settings,
             )
-            expected_org.generate_live_patch(current_org, context, handle)
+            for patch in expected_org.generate_live_patch(current_org, context):
+                handle(patch)
 
             # resolve secrets for collected patches
             if self.resolve_secrets():

--- a/tests/providers/github/integration/helpers/model.py
+++ b/tests/providers/github/integration/helpers/model.py
@@ -79,16 +79,14 @@ class ModelForContext:
         """
         model_cls = determine_model_object(old, new)
 
-        patches: list[LivePatch] = []
-        model_cls.generate_live_patch(
+        patch = model_cls.generate_live_patch(
             expected_object=new,
             current_object=old,
             parent_object=self.get_parent_object(old, new),
             context=self.live_patch_context,
-            handler=lambda p: patches.append(p),  # pyright: ignore[reportArgumentType]
         )
-        assert len(patches) == 1, f"Expected exactly one patch, got {len(patches)}"
-        return patches[0]
+        assert patch is not None, "Expected exactly one patch, got none"
+        return patch
 
     def get_parent_object(self, old: ModelObject | None, new: ModelObject | None) -> ModelObject | None:
         """


### PR DESCRIPTION
Refactor the `generate_live_patch` function to return the generated patch directly instead of using a handler. This change streamlines the process and improves code clarity.

This is like 90% working. Is it going in a reasonable direction? At least for me it's easier and more understandable when functions return the result, instead of using out-parameters. Especially complex ones like handlers.

This is slower as there is no partial handler call as before, not sure if that matters anywhere though.