### PR TITLE
Refactor pull request handling

### DIFF
--- a/otterdog/operations/approve_blueprints.py
+++ b/otterdog/operations/approve_blueprints.py
@@ -121,9 +121,12 @@ class ApproveBlueprintsOperation(Operation):
                         if repo.allow_rebase_merge is True:
                             merge_method = "rebase"
 
-                        result = await provider.pull_request.merge_pull_request(
-                            blueprint.id.org_id, blueprint.id.repo_name, f"{blueprint.remediation_pr}", merge_method
+                        pr = provider.pull_request(
+                            blueprint.id.org_id,
+                            blueprint.id.repo_name,
+                            blueprint.remediation_pr,
                         )
+                        result = await pr.merge_pull_request(merge_method)
 
                         if result["merged"] is True:
                             self.printer.println("[green]merged[/].")

--- a/otterdog/operations/approve_blueprints.py
+++ b/otterdog/operations/approve_blueprints.py
@@ -106,8 +106,6 @@ class ApproveBlueprintsOperation(Operation):
                     return 1
 
                 async with GitHubProvider(credentials) as provider:
-                    rest_api = provider.rest_api
-
                     for blueprint in blueprints:
                         self.printer.print(f"Merging PR #{blueprint.remediation_pr}: ")
 
@@ -123,7 +121,7 @@ class ApproveBlueprintsOperation(Operation):
                         if repo.allow_rebase_merge is True:
                             merge_method = "rebase"
 
-                        result = await rest_api.pull_request.merge_pull_request(
+                        result = await provider.pull_request.merge_pull_request(
                             blueprint.id.org_id, blueprint.id.repo_name, f"{blueprint.remediation_pr}", merge_method
                         )
 

--- a/otterdog/operations/open_pull_request.py
+++ b/otterdog/operations/open_pull_request.py
@@ -21,7 +21,6 @@ from .local_plan import LocalPlanOperation
 
 if TYPE_CHECKING:
     from otterdog.config import OrganizationConfig
-    from otterdog.providers.github.rest import RestApi
 
 
 class OpenPullRequestOperation(Operation):
@@ -128,7 +127,7 @@ class OpenPullRequestOperation(Operation):
                         return 1
 
                     pr_number = await self._create_pull_request(
-                        rest_api,
+                        provider,
                         org_config,
                         default_branch,
                         local_configuration,
@@ -150,11 +149,13 @@ class OpenPullRequestOperation(Operation):
 
     async def _create_pull_request(
         self,
-        rest_api: RestApi,
+        github: GitHubProvider,
         org_config: OrganizationConfig,
         default_branch: str,
         local_configuration: str,
     ) -> str:
+        rest_api = github.rest_api
+
         default_branch_data = await rest_api.reference.get_branch_reference(
             org_config.github_id,
             org_config.config_repo,
@@ -183,7 +184,7 @@ class OpenPullRequestOperation(Operation):
         else:
             body = "This PR has been created automatically using the otterdog cli."
 
-        pull_request_data = await rest_api.pull_request.create_pull_request(
+        pull_request_data = await github.pull_request.create_pull_request(
             org_config.github_id,
             org_config.config_repo,
             self.title,

--- a/otterdog/operations/open_pull_request.py
+++ b/otterdog/operations/open_pull_request.py
@@ -153,7 +153,7 @@ class OpenPullRequestOperation(Operation):
         org_config: OrganizationConfig,
         default_branch: str,
         local_configuration: str,
-    ) -> str:
+    ) -> int:
         rest_api = github.rest_api
 
         default_branch_data = await rest_api.reference.get_branch_reference(
@@ -193,4 +193,4 @@ class OpenPullRequestOperation(Operation):
             body,
         )
 
-        return pull_request_data["number"]
+        return pull_request_data.pr_number

--- a/otterdog/operations/open_pull_request.py
+++ b/otterdog/operations/open_pull_request.py
@@ -184,7 +184,7 @@ class OpenPullRequestOperation(Operation):
         else:
             body = "This PR has been created automatically using the otterdog cli."
 
-        pull_request_data = await github.pull_request.create_pull_request(
+        pull_request_data = await github.create_pull_request(
             org_config.github_id,
             org_config.config_repo,
             self.title,

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import contextlib
 import json
 from asyncio import CancelledError
-from functools import cached_property
 from typing import TYPE_CHECKING
 
 from importlib_resources import files
@@ -50,9 +49,8 @@ class GitHubProvider:
         if credentials is not None:
             self._init_clients()
 
-    @cached_property
-    def pull_request(self):
-        return PullRequest(self.rest_api.requester)
+    def pull_request(self, org_id: str, repo_name: str, pr_number: int) -> PullRequest:
+        return PullRequest(self.rest_api.requester, org_id, repo_name, pr_number)
 
     async def create_pull_request(
         self,
@@ -62,7 +60,7 @@ class GitHubProvider:
         head: str,
         base: str,
         body: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> PullRequest:
         _logger.debug("creating pull request for repo '%s/%s'", org_id, repo_name)
 
         try:
@@ -75,10 +73,14 @@ class GitHubProvider:
             if body is not None:
                 data["body"] = body
 
-            return await self.rest_api.requester.request_json("POST", f"/repos/{org_id}/{repo_name}/pulls", data=data)
+            pr_data = await self.rest_api.requester.request_json(
+                "POST", f"/repos/{org_id}/{repo_name}/pulls", data=data
+            )
+            return PullRequest(self.rest_api.requester, org_id, repo_name, pr_data["number"])
         except GitHubException as ex:
             raise RuntimeError(f"failed creating pull request:\n{ex}") from ex
 
+    # TODO: this should return precached PullRequest objects instead of raw data dicts.
     async def get_pull_requests(
         self,
         org_id: str,

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -17,7 +17,8 @@ from typing import TYPE_CHECKING
 from importlib_resources import files
 
 from otterdog import resources
-from otterdog.providers.github.rest.pull_request_client import PullRequestClient
+from otterdog.providers.github.exception import GitHubException
+from otterdog.providers.github.pull_request import PullRequest
 from otterdog.utils import get_logger, is_ghsa_repo, is_set_and_present
 
 if TYPE_CHECKING:
@@ -51,7 +52,53 @@ class GitHubProvider:
 
     @cached_property
     def pull_request(self):
-        return PullRequestClient(self.rest_api)
+        return PullRequest(self.rest_api.requester)
+
+    async def create_pull_request(
+        self,
+        org_id: str,
+        repo_name: str,
+        title: str,
+        head: str,
+        base: str,
+        body: str | None = None,
+    ) -> dict[str, Any]:
+        _logger.debug("creating pull request for repo '%s/%s'", org_id, repo_name)
+
+        try:
+            data = {
+                "title": title,
+                "head": head,
+                "base": base,
+            }
+
+            if body is not None:
+                data["body"] = body
+
+            return await self.rest_api.requester.request_json("POST", f"/repos/{org_id}/{repo_name}/pulls", data=data)
+        except GitHubException as ex:
+            raise RuntimeError(f"failed creating pull request:\n{ex}") from ex
+
+    async def get_pull_requests(
+        self,
+        org_id: str,
+        repo_name: str,
+        state: str = "all",
+        base_ref: str | None = None,
+    ) -> list[dict[str, Any]]:
+        _logger.debug("getting pull requests from repo '%s/%s'", org_id, repo_name)
+
+        try:
+            params = {"state": state}
+
+            if base_ref is not None:
+                params.update({"base": base_ref})
+
+            return await self.rest_api.requester.request_paged_json(
+                "GET", f"/repos/{org_id}/{repo_name}/pulls", params=params
+            )
+        except GitHubException as ex:
+            raise RuntimeError(f"failed retrieving pull requests:\n{ex}") from ex
 
     async def __aenter__(self):
         return self

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import contextlib
 import json
 from asyncio import CancelledError
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from importlib_resources import files
 
 from otterdog import resources
+from otterdog.providers.github.rest.pull_request_client import PullRequestClient
 from otterdog.utils import get_logger, is_ghsa_repo, is_set_and_present
 
 if TYPE_CHECKING:
@@ -46,6 +48,10 @@ class GitHubProvider:
 
         if credentials is not None:
             self._init_clients()
+
+    @cached_property
+    def pull_request(self):
+        return PullRequestClient(self.rest_api)
 
     async def __aenter__(self):
         return self

--- a/otterdog/providers/github/pull_request.py
+++ b/otterdog/providers/github/pull_request.py
@@ -127,6 +127,12 @@ class PullRequest:
         commit_message: str | None = None,
         merge_method: str = "squash",
     ) -> bool:
+        """
+        @param commit_message is only used for "squash" and "merge" merge methods, and ignored for "rebase" method
+        @param merge_method can be one of "merge", "squash", or "rebase"
+        """
+        # https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls?apiVersion=2022-11-28#merge-a-pull-request
+
         _logger.debug("merging %s", self)
 
         try:

--- a/otterdog/providers/github/pull_request.py
+++ b/otterdog/providers/github/pull_request.py
@@ -16,93 +16,74 @@ _logger = get_logger(__name__)
 
 
 class PullRequest:
-    def __init__(self, rest_api_requester: Requester):
+    def __init__(self, rest_api_requester: Requester, org_id: str, repo_name: str, pr_number: int) -> None:
         self.requester = rest_api_requester
+        self.org_id = org_id
+        self.repo_name = repo_name
+        self.pr_number = pr_number
 
-    async def get_pull_request(
+    def __str__(self) -> str:
+        return f"PullRequest(org_id={self.org_id}, repo_name={self.repo_name}, pr_number={self.pr_number})"
+
+    def _base_path(self) -> str:
+        return f"/repos/{self.org_id}/{self.repo_name}/pulls/{self.pr_number}"
+
+    async def get_data(
         self,
-        org_id: str,
-        repo_name: str,
-        pull_request_number: str,
     ) -> dict[str, Any]:
-        _logger.debug("getting pull request with number '%s' from repo '%s/%s'", pull_request_number, org_id, repo_name)
+        _logger.debug("getting live data for %s", self)
 
         try:
-            return await self.requester.request_json("GET", f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}")
+            return await self.requester.request_json("GET", self._base_path())
         except GitHubException as ex:
-            raise RuntimeError(f"failed retrieving pull request:\n{ex}") from ex
+            raise RuntimeError(f"failed retrieving {self}") from ex
 
     async def merge_pull_request(
         self,
-        org_id: str,
-        repo_name: str,
-        pull_request_number: str,
         method: str,
     ) -> dict[str, Any]:
-        _logger.debug("merging pull request #%s for repo '%s/%s'", pull_request_number, org_id, repo_name)
+        _logger.debug("merging %s", self)
 
         try:
             data = {"merge_method": method}
-            return await self.requester.request_json(
-                "PUT", f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}/merge", data=data
-            )
+            return await self.requester.request_json("PUT", self._base_path() + "/merge", data=data)
         except GitHubException as ex:
-            raise RuntimeError(f"failed merging pull request:\n{ex}") from ex
+            raise RuntimeError(f"failed merging {self}") from ex
 
     async def get_commits(
         self,
-        org_id: str,
-        repo_name: str,
-        pull_request_number: str,
     ) -> list[dict[str, Any]]:
-        _logger.debug("getting commits for pull request #%s from repo '%s/%s'", pull_request_number, org_id, repo_name)
+        _logger.debug("getting commits for %s", self)
 
         try:
-            return await self.requester.request_paged_json(
-                "GET", f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}/commits"
-            )
+            return await self.requester.request_paged_json("GET", self._base_path() + "/commits")
         except GitHubException as ex:
-            raise RuntimeError(f"failed retrieving pull request commits:\n{ex}") from ex
+            raise RuntimeError(f"failed retrieving commits for {self}") from ex
 
     async def get_reviews(
         self,
-        org_id: str,
-        repo_name: str,
-        pull_request_number: str,
     ) -> list[dict[str, Any]]:
-        _logger.debug("getting reviews for pull request #%s from repo '%s/%s'", pull_request_number, org_id, repo_name)
+        _logger.debug("getting reviews for %s", self)
 
         try:
-            return await self.requester.request_paged_json(
-                "GET", f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}/reviews"
-            )
+            return await self.requester.request_paged_json("GET", self._base_path() + "/reviews")
         except GitHubException as ex:
-            raise RuntimeError(f"failed retrieving pull request reviews:\n{ex}") from ex
+            raise RuntimeError(f"failed retrieving reviews for {self}") from ex
 
     async def request_reviews(
         self,
-        org_id: str,
-        repo_name: str,
-        pull_request_number: str,
         reviewers: list[str] | None = None,
         team_reviewers: list[str] | None = None,
     ) -> bool:
         _logger.debug(
-            "requesting reviews for pull request #%s in repo '%s/%s': %s, %s",
-            pull_request_number,
-            org_id,
-            repo_name,
+            "requesting reviews for %s: %s, %s",
+            self,
             reviewers,
             team_reviewers,
         )
 
         if (reviewers is None or len(reviewers) == 0) and (team_reviewers is None or len(team_reviewers) == 0):
-            _logger.error(
-                "requesting reviews for pull request #%s in repo '%s/%s' without any reviewer specified",
-                pull_request_number,
-                org_id,
-                repo_name,
-            )
+            _logger.error("requesting reviews for %s without any reviewer specified", self)
             return False
 
         try:
@@ -116,48 +97,37 @@ class PullRequest:
 
             status, body = await self.requester.request_raw(
                 "POST",
-                f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}/requested_reviewers",
+                self._base_path() + "/requested_reviewers",
                 data=json.dumps(data),
             )
 
             if status == 201:
                 return True
             elif status == 422:
-                _logger.warning("failed to request reviews for reviewers (%s, %s): %s", reviewers, team_reviewers, body)
+                _logger.warning("failed to request reviews for %s: %s", self, body)
                 return False
             else:
-                raise RuntimeError(
-                    f"failed requesting reviews for pull request #{pull_request_number} in repo "
-                    f"'{org_id}/{repo_name}'\n{status}: {body}"
-                )
+                raise RuntimeError(f"failed requesting reviews for {self}\n{status}: {body}")
 
         except GitHubException as ex:
-            raise RuntimeError(f"failed requesting pull request reviews:\n{ex}") from ex
+            raise RuntimeError(f"failed requesting reviews for {self}") from ex
 
     async def get_files(
         self,
-        org_id: str,
-        repo_name: str,
-        pull_request_number: str,
     ) -> list[dict[str, Any]]:
-        _logger.debug("getting files for pull request #%s from repo '%s/%s'", pull_request_number, org_id, repo_name)
+        _logger.debug("getting files for %s", self)
 
         try:
-            return await self.requester.request_paged_json(
-                "GET", f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}/files"
-            )
+            return await self.requester.request_paged_json("GET", self._base_path() + "/files")
         except GitHubException as ex:
-            raise RuntimeError(f"failed retrieving pull request files:\n{ex}") from ex
+            raise RuntimeError(f"failed retrieving files for {self}") from ex
 
     async def merge(
         self,
-        org_id: str,
-        repo_name: str,
-        pull_request_number: str,
         commit_message: str | None = None,
         merge_method: str = "squash",
     ) -> bool:
-        _logger.debug("merging pull request #%s from repo '%s/%s'", pull_request_number, org_id, repo_name)
+        _logger.debug("merging %s", self)
 
         try:
             data = {
@@ -169,9 +139,9 @@ class PullRequest:
 
             response = await self.requester.request_json(
                 "PUT",
-                f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}/merge",
+                self._base_path() + "/merge",
                 data=data,
             )
             return response["merged"]
         except GitHubException as ex:
-            raise RuntimeError(f"failed merging pull request:\n{ex}") from ex
+            raise RuntimeError(f"failed merging {self}") from ex

--- a/otterdog/providers/github/pull_request.py
+++ b/otterdog/providers/github/pull_request.py
@@ -10,15 +10,14 @@ from typing import Any
 
 from otterdog.logging import get_logger
 from otterdog.providers.github.exception import GitHubException
-
-from . import RestApi, RestClient
+from otterdog.providers.github.rest.requester import Requester
 
 _logger = get_logger(__name__)
 
 
-class PullRequestClient(RestClient):
-    def __init__(self, rest_api: RestApi):
-        super().__init__(rest_api)
+class PullRequest:
+    def __init__(self, rest_api_requester: Requester):
+        self.requester = rest_api_requester
 
     async def get_pull_request(
         self,
@@ -32,50 +31,6 @@ class PullRequestClient(RestClient):
             return await self.requester.request_json("GET", f"/repos/{org_id}/{repo_name}/pulls/{pull_request_number}")
         except GitHubException as ex:
             raise RuntimeError(f"failed retrieving pull request:\n{ex}") from ex
-
-    async def create_pull_request(
-        self,
-        org_id: str,
-        repo_name: str,
-        title: str,
-        head: str,
-        base: str,
-        body: str | None = None,
-    ) -> dict[str, Any]:
-        _logger.debug("creating pull request for repo '%s/%s'", org_id, repo_name)
-
-        try:
-            data = {
-                "title": title,
-                "head": head,
-                "base": base,
-            }
-
-            if body is not None:
-                data["body"] = body
-
-            return await self.requester.request_json("POST", f"/repos/{org_id}/{repo_name}/pulls", data=data)
-        except GitHubException as ex:
-            raise RuntimeError(f"failed creating pull request:\n{ex}") from ex
-
-    async def get_pull_requests(
-        self,
-        org_id: str,
-        repo_name: str,
-        state: str = "all",
-        base_ref: str | None = None,
-    ) -> list[dict[str, Any]]:
-        _logger.debug("getting pull requests from repo '%s/%s'", org_id, repo_name)
-
-        try:
-            params = {"state": state}
-
-            if base_ref is not None:
-                params.update({"base": base_ref})
-
-            return await self.requester.request_paged_json("GET", f"/repos/{org_id}/{repo_name}/pulls", params=params)
-        except GitHubException as ex:
-            raise RuntimeError(f"failed retrieving pull requests:\n{ex}") from ex
 
     async def merge_pull_request(
         self,

--- a/otterdog/providers/github/rest/__init__.py
+++ b/otterdog/providers/github/rest/__init__.py
@@ -95,12 +95,6 @@ class RestApi:
         return IssueClient(self)
 
     @cached_property
-    def pull_request(self):
-        from .pull_request_client import PullRequestClient
-
-        return PullRequestClient(self)
-
-    @cached_property
     def reference(self):
         from .reference_client import ReferenceClient
 

--- a/otterdog/providers/github/rest/requester.py
+++ b/otterdog/providers/github/rest/requester.py
@@ -29,6 +29,8 @@ _logger = get_logger(__name__)
 
 
 class Requester:
+    """Low-level access to the GitHub REST API, handling authentication, caching, retries, and statistics."""
+
     def __init__(
         self,
         auth_strategy: AuthStrategy | None,

--- a/otterdog/webapp/policies/macos_large_runners.py
+++ b/otterdog/webapp/policies/macos_large_runners.py
@@ -42,12 +42,12 @@ class MacOSLargeRunnersUsagePolicy(Policy):
 
         uses_restricted_runner, permitted = self._is_workflow_job_permitted(payload.labels)
         if not permitted:
-            from otterdog.webapp.utils import get_rest_api_for_installation
+            from otterdog.webapp.utils import get_github_provider_for_installation
 
             run_id = payload.run_id
 
-            rest_api = await get_rest_api_for_installation(installation_id)
-            cancelled = await rest_api.action.cancel_workflow_run(github_id, repo_name, run_id)
+            github_provider = await get_github_provider_for_installation(installation_id)
+            cancelled = await github_provider.rest_api.action.cancel_workflow_run(github_id, repo_name, run_id)
             logger.info(f"cancelled workflow run #{run_id} in repo '{github_id}/{repo_name}': success={cancelled}")
 
         await self._update_status(github_id, uses_restricted_runner, permitted)

--- a/otterdog/webapp/tasks/__init__.py
+++ b/otterdog/webapp/tasks/__init__.py
@@ -28,8 +28,7 @@ from otterdog.webapp.db.service import (
     schedule_task,
 )
 from otterdog.webapp.utils import (
-    get_graphql_api_for_installation,
-    get_rest_api_for_installation,
+    get_github_provider_for_installation,
     get_temporary_base_directory,
 )
 
@@ -112,17 +111,21 @@ class Task(ABC, Generic[T]):
 class InstallationBasedTask(Protocol):
     installation_id: int
 
-    __rest_api: RestApi | None = None
-    __graphql_api: GraphQLClient | None = None
+    __github_provider: GitHubProvider | None = None
 
     __rest_statistics: RequestStatistics | None = None
     __graphql_statistics: RequestStatistics | None = None
 
     @property
+    async def github_provider(self) -> GitHubProvider:
+        if self.__github_provider is None:
+            self.__github_provider = await get_github_provider_for_installation(self.installation_id)
+        return self.__github_provider
+
+    @property
     async def rest_api(self) -> RestApi:
-        if self.__rest_api is None:
-            self.__rest_api = await get_rest_api_for_installation(self.installation_id)
-        return self.__rest_api
+        github_provider = await self.github_provider
+        return github_provider.rest_api
 
     @property
     def rest_statistics(self) -> RequestStatistics:
@@ -138,9 +141,8 @@ class InstallationBasedTask(Protocol):
 
     @property
     async def graphql_api(self) -> GraphQLClient:
-        if self.__graphql_api is None:
-            self.__graphql_api = await get_graphql_api_for_installation(self.installation_id)
-        return self.__graphql_api
+        github_provider = await self.github_provider
+        return github_provider.graphql_client
 
     def _merge_rest_statistics(self, other: RequestStatistics) -> None:
         self.rest_statistics.merge(other)
@@ -153,11 +155,9 @@ class InstallationBasedTask(Protocol):
         self._merge_graphql_statistics(provider.graphql_client.statistics)
 
     def _update_task_model(self, task: TaskModel) -> None:
-        if self.__rest_api is not None:
-            self._merge_rest_statistics(self.__rest_api.statistics)
-
-        if self.__graphql_api is not None:
-            self._merge_graphql_statistics(self.__graphql_api.statistics)
+        if self.__github_provider is not None:
+            self._merge_rest_statistics(self.__github_provider.rest_api.statistics)
+            self._merge_graphql_statistics(self.__github_provider.graphql_client.statistics)
 
         if self.rest_statistics.total_requests == 0:
             cache_stats = "rest: no requests"
@@ -255,11 +255,8 @@ class InstallationBasedTask(Protocol):
         )
 
     async def _cleanup(self) -> None:
-        if self.__rest_api is not None:
-            await self.__rest_api.close()
-
-        if self.__graphql_api is not None:
-            await self.__graphql_api.close()
+        if self.__github_provider is not None:
+            await self.__github_provider.close()
 
 
 async def get_organization_config(

--- a/otterdog/webapp/tasks/apply_changes.py
+++ b/otterdog/webapp/tasks/apply_changes.py
@@ -68,8 +68,8 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
         )
 
         if isinstance(self.pull_request_or_number, int):
-            rest_api = await self.rest_api
-            response = await rest_api.pull_request.get_pull_request(
+            github = await self.github_provider
+            response = await github.pull_request.get_pull_request(
                 self.org_id, self.repo_name, str(self.pull_request_or_number)
             )
             self._pull_request = PullRequest.model_validate(response)

--- a/otterdog/webapp/tasks/apply_changes.py
+++ b/otterdog/webapp/tasks/apply_changes.py
@@ -69,9 +69,8 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
 
         if isinstance(self.pull_request_or_number, int):
             github = await self.github_provider
-            response = await github.pull_request.get_pull_request(
-                self.org_id, self.repo_name, str(self.pull_request_or_number)
-            )
+            pr = github.pull_request(self.org_id, self.repo_name, self.pull_request_or_number)
+            response = await pr.get_data()
             self._pull_request = PullRequest.model_validate(response)
         else:
             self._pull_request = self.pull_request_or_number

--- a/otterdog/webapp/tasks/apply_changes.py
+++ b/otterdog/webapp/tasks/apply_changes.py
@@ -118,7 +118,10 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
                 comment = await render_template(
                     "comment/wrong_team_apply_comment.txt", admin_teams=get_full_admin_team_slugs(self.org_id)
                 )
-                await rest_api.issue.create_comment(self.org_id, self.repo_name, str(self.pull_request_number), comment)
+                provider = await self.github_provider
+                await provider.rest_api.issue.create_comment(
+                    self.org_id, self.repo_name, str(self.pull_request_number), comment
+                )
 
                 self.logger.error(
                     f"apply for pull request #{self.pull_request_number} triggered by user '{self.author}' "
@@ -222,7 +225,10 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
                 admin_teams=get_full_admin_team_slugs(self.org_id),
             )
 
-            await rest_api.issue.create_comment(self.org_id, org_config.config_repo, pull_request_number, result)
+            github_provider = await self.github_provider
+            await github_provider.rest_api.issue.create_comment(
+                self.org_id, org_config.config_repo, pull_request_number, result
+            )
 
             return apply_result
 

--- a/otterdog/webapp/tasks/auto_merge_comment.py
+++ b/otterdog/webapp/tasks/auto_merge_comment.py
@@ -45,8 +45,8 @@ class AutoMergeCommentTask(InstallationBasedTask, Task[None]):
         ):
             comment = await render_template("comment/auto_merge_comment.txt")
 
-            rest_api = await self.rest_api
-            await rest_api.issue.create_comment(
+            github_provider = await self.github_provider
+            await github_provider.rest_api.issue.create_comment(
                 self.org_id,
                 self.repo_name,
                 str(self.pull_request_number),

--- a/otterdog/webapp/tasks/blueprints/__init__.py
+++ b/otterdog/webapp/tasks/blueprints/__init__.py
@@ -160,7 +160,7 @@ class BlueprintTask(InstallationBasedTask, Task[CheckResult], ABC):
         )
 
         github = await self.github_provider
-        created_pr = await github.pull_request.create_pull_request(
+        created_pr = await github.create_pull_request(
             self.org_id,
             self.repo_name,
             pr_title,

--- a/otterdog/webapp/tasks/blueprints/__init__.py
+++ b/otterdog/webapp/tasks/blueprints/__init__.py
@@ -122,8 +122,8 @@ class BlueprintTask(InstallationBasedTask, Task[CheckResult], ABC):
             return False
 
     async def _find_existing_pull_request(self, default_branch: str) -> int | None:
-        rest_api = await self.rest_api
-        open_pull_requests = await rest_api.pull_request.get_pull_requests(
+        github = await self.github_provider
+        open_pull_requests = await github.pull_request.get_pull_requests(
             self.org_id, self.repo_name, "open", default_branch
         )
 
@@ -159,8 +159,8 @@ class BlueprintTask(InstallationBasedTask, Task[CheckResult], ABC):
             dashboard_url=dashboard_url,
         )
 
-        rest_api = await self.rest_api
-        created_pr = await rest_api.pull_request.create_pull_request(
+        github = await self.github_provider
+        created_pr = await github.pull_request.create_pull_request(
             self.org_id,
             self.repo_name,
             pr_title,
@@ -172,8 +172,8 @@ class BlueprintTask(InstallationBasedTask, Task[CheckResult], ABC):
         pull_request_number = created_pr["number"]
 
         if team_reviewers is not None and len(team_reviewers) > 0:
-            await rest_api.pull_request.request_reviews(
-                self.org_id, self.repo_name, pull_request_number, team_reviewers=team_reviewers
+            await github.pull_request.request_reviews(
+                self.org_id, self.repo_name, str(pull_request_number), team_reviewers=team_reviewers
             )
 
         return pull_request_number

--- a/otterdog/webapp/tasks/blueprints/__init__.py
+++ b/otterdog/webapp/tasks/blueprints/__init__.py
@@ -123,9 +123,7 @@ class BlueprintTask(InstallationBasedTask, Task[CheckResult], ABC):
 
     async def _find_existing_pull_request(self, default_branch: str) -> int | None:
         github = await self.github_provider
-        open_pull_requests = await github.pull_request.get_pull_requests(
-            self.org_id, self.repo_name, "open", default_branch
-        )
+        open_pull_requests = await github.get_pull_requests(self.org_id, self.repo_name, "open", default_branch)
 
         for pr in open_pull_requests:
             if pr["head"]["ref"] == self.branch_name:
@@ -169,11 +167,10 @@ class BlueprintTask(InstallationBasedTask, Task[CheckResult], ABC):
             pr_body,
         )
 
-        pull_request_number = created_pr["number"]
+        pull_request_number = created_pr.pr_number
 
         if team_reviewers is not None and len(team_reviewers) > 0:
-            await github.pull_request.request_reviews(
-                self.org_id, self.repo_name, str(pull_request_number), team_reviewers=team_reviewers
-            )
+            pr = github.pull_request(self.org_id, self.repo_name, pull_request_number)
+            await pr.request_reviews(team_reviewers=team_reviewers)
 
         return pull_request_number

--- a/otterdog/webapp/tasks/check_sync.py
+++ b/otterdog/webapp/tasks/check_sync.py
@@ -83,9 +83,8 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
         rest_api = github.rest_api
 
         if isinstance(self.pull_request_or_number, int):
-            response = await github.pull_request.get_pull_request(
-                self.org_id, self.repo_name, str(self.pull_request_number)
-            )
+            pr = github.pull_request(self.org_id, self.repo_name, self.pull_request_or_number)
+            response = await pr.get_data()
             self._pull_request = PullRequest.model_validate(response)
         else:
             self._pull_request = self.pull_request_or_number
@@ -93,11 +92,8 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
         # do not perform checks every time a pull request is synchronized
         # if the last check was done within an hour
         if self.is_triggered_from_comment is False:
-            commits = await github.pull_request.get_commits(
-                self.org_id,
-                self.repo_name,
-                str(self.pull_request_number),
-            )
+            pr = github.pull_request(self.org_id, self.repo_name, self.pull_request_number)
+            commits = await pr.get_commits()
 
             if len(commits) > 1:
                 previous_commit = commits[-2]

--- a/otterdog/webapp/tasks/check_sync.py
+++ b/otterdog/webapp/tasks/check_sync.py
@@ -199,8 +199,8 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
             )
 
             if comment is not None:
-                rest_api = await self.rest_api
-                await rest_api.issue.create_comment(
+                github_provider = await self.github_provider
+                await github_provider.rest_api.issue.create_comment(
                     self.org_id,
                     org_config.config_repo,
                     self.pull_request_number,

--- a/otterdog/webapp/tasks/check_sync.py
+++ b/otterdog/webapp/tasks/check_sync.py
@@ -79,10 +79,11 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
             self.repo_name,
         )
 
-        rest_api = await self.rest_api
+        github = await self.github_provider
+        rest_api = github.rest_api
 
         if isinstance(self.pull_request_or_number, int):
-            response = await rest_api.pull_request.get_pull_request(
+            response = await github.pull_request.get_pull_request(
                 self.org_id, self.repo_name, str(self.pull_request_number)
             )
             self._pull_request = PullRequest.model_validate(response)
@@ -92,7 +93,7 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
         # do not perform checks every time a pull request is synchronized
         # if the last check was done within an hour
         if self.is_triggered_from_comment is False:
-            commits = await rest_api.pull_request.get_commits(
+            commits = await github.pull_request.get_commits(
                 self.org_id,
                 self.repo_name,
                 str(self.pull_request_number),

--- a/otterdog/webapp/tasks/complete_pull_request.py
+++ b/otterdog/webapp/tasks/complete_pull_request.py
@@ -75,7 +75,10 @@ class CompletePullRequestTask(InstallationBasedTask, Task[None]):
             comment = await render_template(
                 "comment/wrong_team_done_comment.txt", admin_teams=get_full_admin_team_slugs(self.org_id)
             )
-            await rest_api.issue.create_comment(self.org_id, self.repo_name, str(self.pull_request_number), comment)
+            github_provider = await self.github_provider
+            await github_provider.rest_api.issue.create_comment(
+                self.org_id, self.repo_name, self.pull_request_number, comment
+            )
 
             self.logger.error(
                 f"apply for pull request #{self.pull_request_number} triggered by user '{self.author}' "
@@ -91,8 +94,10 @@ class CompletePullRequestTask(InstallationBasedTask, Task[None]):
         await update_pull_request(self._pr_model)
 
         comment = await render_template("comment/done_comment.txt")
-        rest_api = await self.rest_api
-        await rest_api.issue.create_comment(self.org_id, self.repo_name, str(self.pull_request_number), comment)
+        github_provider = await self.github_provider
+        await github_provider.rest_api.issue.create_comment(
+            self.org_id, self.repo_name, self.pull_request_number, comment
+        )
 
     def __repr__(self) -> str:
         return f"CompletePullRequestTask(repo={self.org_id}/{self.repo_name}, pull_request=#{self.pull_request_number})"

--- a/otterdog/webapp/tasks/complete_pull_request.py
+++ b/otterdog/webapp/tasks/complete_pull_request.py
@@ -77,7 +77,7 @@ class CompletePullRequestTask(InstallationBasedTask, Task[None]):
             )
             github_provider = await self.github_provider
             await github_provider.rest_api.issue.create_comment(
-                self.org_id, self.repo_name, self.pull_request_number, comment
+                self.org_id, self.repo_name, self.pull_request_number, body=comment
             )
 
             self.logger.error(
@@ -96,7 +96,7 @@ class CompletePullRequestTask(InstallationBasedTask, Task[None]):
         comment = await render_template("comment/done_comment.txt")
         github_provider = await self.github_provider
         await github_provider.rest_api.issue.create_comment(
-            self.org_id, self.repo_name, self.pull_request_number, comment
+            self.org_id, self.repo_name, self.pull_request_number, body=comment
         )
 
     def __repr__(self) -> str:

--- a/otterdog/webapp/tasks/fetch_all_pull_requests.py
+++ b/otterdog/webapp/tasks/fetch_all_pull_requests.py
@@ -34,9 +34,9 @@ class FetchAllPullRequestsTask(InstallationBasedTask, Task[None]):
             self.repo_name,
         )
 
-        rest_api = await self.rest_api
+        github = await self.github_provider
 
-        all_pull_requests = await rest_api.pull_request.get_pull_requests(
+        all_pull_requests = await github.pull_request.get_pull_requests(
             self.org_id, self.repo_name, state="all", base_ref="main"
         )
 

--- a/otterdog/webapp/tasks/fetch_all_pull_requests.py
+++ b/otterdog/webapp/tasks/fetch_all_pull_requests.py
@@ -36,9 +36,7 @@ class FetchAllPullRequestsTask(InstallationBasedTask, Task[None]):
 
         github = await self.github_provider
 
-        all_pull_requests = await github.pull_request.get_pull_requests(
-            self.org_id, self.repo_name, state="all", base_ref="main"
-        )
+        all_pull_requests = await github.get_pull_requests(self.org_id, self.repo_name, state="all", base_ref="main")
 
         for pr in all_pull_requests:
             pr_from_github = PullRequest.model_validate(pr)

--- a/otterdog/webapp/tasks/help_comment.py
+++ b/otterdog/webapp/tasks/help_comment.py
@@ -54,7 +54,6 @@ class HelpCommentTask(InstallationBasedTask, Task[None]):
             self.repo_name,
         )
 
-        rest_api = await self.rest_api
         comment = await render_template("comment/help_comment.txt")
 
         await self.minimize_outdated_comments(
@@ -64,7 +63,8 @@ class HelpCommentTask(InstallationBasedTask, Task[None]):
             "<!-- Otterdog Comment: help -->",
         )
 
-        await rest_api.issue.create_comment(
+        github_provider = await self.github_provider
+        await github_provider.rest_api.issue.create_comment(
             self.org_id,
             self.repo_name,
             str(self.pull_request_number),

--- a/otterdog/webapp/tasks/merge_pull_request.py
+++ b/otterdog/webapp/tasks/merge_pull_request.py
@@ -87,9 +87,9 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
                 f"pull request #{self.pull_request_number} merge in repo '{self.org_id}/{self.repo_name}' triggered by user '{self.author}' "
                 f"is not eligible for auto-merge, skipping. Problems: {', '.join(problems)}"
             )
-            rest_api = await self.rest_api
             comment = await render_template("comment/automerge_problems.txt", problems=problems)
-            await rest_api.issue.create_comment(
+            github_provider = await self.github_provider
+            await github_provider.rest_api.issue.create_comment(
                 self.org_id,
                 self.repo_name,
                 str(self.pull_request_number),

--- a/otterdog/webapp/tasks/merge_pull_request.py
+++ b/otterdog/webapp/tasks/merge_pull_request.py
@@ -50,9 +50,8 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
             return problems
 
         github = await self.github_provider
-        response = await github.pull_request.get_pull_request(
-            self.org_id, self.repo_name, str(self.pull_request_number)
-        )
+        pr = github.pull_request(self.org_id, self.repo_name, self.pull_request_number)
+        response = await pr.get_data()
         pull_request = PullRequest.model_validate(response)
 
         if self.author != pull_request.user.login:
@@ -100,7 +99,8 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
 
     async def _execute(self) -> None:
         github = await self.github_provider
-        merged = await github.pull_request.merge(self.org_id, self.repo_name, str(self.pull_request_number))
+        pr = github.pull_request(self.org_id, self.repo_name, self.pull_request_number)
+        merged = await pr.merge()
 
         if merged is True:
             self.logger.info(f"Pull Request #{self.pull_request_number} auto-merged")

--- a/otterdog/webapp/tasks/merge_pull_request.py
+++ b/otterdog/webapp/tasks/merge_pull_request.py
@@ -46,12 +46,11 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
         else:
             self._pr_model = pr_model
 
-        rest_api = await self.rest_api
-
         if problems := pr_model.automerge_problems():
             return problems
 
-        response = await rest_api.pull_request.get_pull_request(
+        github = await self.github_provider
+        response = await github.pull_request.get_pull_request(
             self.org_id, self.repo_name, str(self.pull_request_number)
         )
         pull_request = PullRequest.model_validate(response)
@@ -100,8 +99,8 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
         return True
 
     async def _execute(self) -> None:
-        rest_api = await self.rest_api
-        merged = await rest_api.pull_request.merge(self.org_id, self.repo_name, str(self.pull_request_number))
+        github = await self.github_provider
+        merged = await github.pull_request.merge(self.org_id, self.repo_name, str(self.pull_request_number))
 
         if merged is True:
             self.logger.info(f"Pull Request #{self.pull_request_number} auto-merged")

--- a/otterdog/webapp/tasks/retrieve_team_membership.py
+++ b/otterdog/webapp/tasks/retrieve_team_membership.py
@@ -46,9 +46,8 @@ class RetrieveTeamMembershipTask(InstallationBasedTask, Task[None]):
     async def _pre_execute(self) -> bool:
         if isinstance(self.pull_request_or_number, int):
             github = await self.github_provider
-            response = await github.pull_request.get_pull_request(
-                self.org_id, self.repo_name, str(self.pull_request_number)
-            )
+            pr = github.pull_request(self.org_id, self.repo_name, self.pull_request_number)
+            response = await pr.get_data()
             self._pull_request = PullRequest.model_validate(response)
         else:
             self._pull_request = self.pull_request_or_number

--- a/otterdog/webapp/tasks/retrieve_team_membership.py
+++ b/otterdog/webapp/tasks/retrieve_team_membership.py
@@ -45,8 +45,8 @@ class RetrieveTeamMembershipTask(InstallationBasedTask, Task[None]):
 
     async def _pre_execute(self) -> bool:
         if isinstance(self.pull_request_or_number, int):
-            rest_api = await self.rest_api
-            response = await rest_api.pull_request.get_pull_request(
+            github = await self.github_provider
+            response = await github.pull_request.get_pull_request(
                 self.org_id, self.repo_name, str(self.pull_request_number)
             )
             self._pull_request = PullRequest.model_validate(response)

--- a/otterdog/webapp/tasks/update_pull_request.py
+++ b/otterdog/webapp/tasks/update_pull_request.py
@@ -47,12 +47,9 @@ class UpdatePullRequestTask(InstallationBasedTask, Task[None]):
         )
 
         if self.review is not None:
-            rest_api = await self.rest_api
-
             # check if the PR was approved by a team eligible for auto-merge
-            reviews = await rest_api.pull_request.get_reviews(
-                self.org_id, self.repo_name, str(self.pull_request_number)
-            )
+            github = await self.github_provider
+            reviews = await github.pull_request.get_reviews(self.org_id, self.repo_name, str(self.pull_request_number))
 
             approved_by_users = [x["user"]["login"] for x in filter(lambda x: x["state"] == "APPROVED", reviews)]
 

--- a/otterdog/webapp/tasks/update_pull_request.py
+++ b/otterdog/webapp/tasks/update_pull_request.py
@@ -49,7 +49,8 @@ class UpdatePullRequestTask(InstallationBasedTask, Task[None]):
         if self.review is not None:
             # check if the PR was approved by a team eligible for auto-merge
             github = await self.github_provider
-            reviews = await github.pull_request.get_reviews(self.org_id, self.repo_name, str(self.pull_request_number))
+            pr = github.pull_request(self.org_id, self.repo_name, self.pull_request_number)
+            reviews = await pr.get_reviews()
 
             approved_by_users = [x["user"]["login"] for x in filter(lambda x: x["state"] == "APPROVED", reviews)]
 

--- a/otterdog/webapp/tasks/validate_pull_request.py
+++ b/otterdog/webapp/tasks/validate_pull_request.py
@@ -78,9 +78,8 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
     async def _pre_execute(self) -> bool:
         if isinstance(self.pull_request_or_number, int):
             github = await self.github_provider
-            response = await github.pull_request.get_pull_request(
-                self.org_id, self.repo_name, str(self.pull_request_or_number)
-            )
+            pr = github.pull_request(self.org_id, self.repo_name, self.pull_request_or_number)
+            response = await pr.get_data()
             self._pull_request = PullRequest.model_validate(response)
         else:
             self._pull_request = self.pull_request_or_number
@@ -268,11 +267,11 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
             self.schedule_automerge_task(self.org_id, self.repo_name, self.pull_request_number)
 
     async def _get_pull_request_files(self, github: GitHubProvider) -> list[str]:
-        pull_request_data = await github.pull_request.get_files(
+        pull_request_data = await github.pull_request(
             self.org_id,
             self.repo_name,
-            str(self.pull_request_number),
-        )
+            self.pull_request_number,
+        ).get_files()
         return [x["filename"] for x in pull_request_data]
 
     def __repr__(self) -> str:

--- a/otterdog/webapp/tasks/validate_pull_request.py
+++ b/otterdog/webapp/tasks/validate_pull_request.py
@@ -32,7 +32,7 @@ from otterdog.webapp.webhook.github_models import PullRequest, Repository
 if TYPE_CHECKING:
     from otterdog.operations.diff_operation import DiffStatus
     from otterdog.operations.validate import ValidationStatus
-    from otterdog.providers.github.rest import RestApi
+    from otterdog.providers.github import GitHubProvider
 
 
 @dataclass
@@ -77,8 +77,8 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
 
     async def _pre_execute(self) -> bool:
         if isinstance(self.pull_request_or_number, int):
-            rest_api = await self.rest_api
-            response = await rest_api.pull_request.get_pull_request(
+            github = await self.github_provider
+            response = await github.pull_request.get_pull_request(
                 self.org_id, self.repo_name, str(self.pull_request_or_number)
             )
             self._pull_request = PullRequest.model_validate(response)
@@ -105,14 +105,14 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
         )
 
         async with self.get_organization_config() as org_config:
-            rest_api = await self.rest_api
+            github = await self.github_provider
 
             org_config_file = org_config.jsonnet_config.org_config_file
 
             # get BASE config
             base_file = org_config_file + "-BASE"
             await fetch_config_from_github(
-                rest_api,
+                github.rest_api,
                 self.org_id,
                 self.org_id,
                 org_config.config_repo,
@@ -126,7 +126,7 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
             # get HEAD config from PR
             head_file = org_config_file
             await fetch_config_from_github(
-                rest_api,
+                github.rest_api,
                 self.org_id,
                 head_repo.owner.login,
                 head_repo.name,
@@ -136,7 +136,7 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
 
             validation_result = ValidationResult()
 
-            for file in await self._get_pull_request_files(rest_api):
+            for file in await self._get_pull_request_files(github):
                 self.logger.debug(f"touched file: {file}")
                 if file != f"otterdog/{self.org_id}.jsonnet":
                     validation_result.touches_non_configuration = True
@@ -267,8 +267,8 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
         if pull_request_model.can_be_automerged():
             self.schedule_automerge_task(self.org_id, self.repo_name, self.pull_request_number)
 
-    async def _get_pull_request_files(self, rest_api: RestApi) -> list[str]:
-        pull_request_data = await rest_api.pull_request.get_files(
+    async def _get_pull_request_files(self, github: GitHubProvider) -> list[str]:
+        pull_request_data = await github.pull_request.get_files(
             self.org_id,
             self.repo_name,
             str(self.pull_request_number),

--- a/otterdog/webapp/templates/comment/automerge_problems.txt
+++ b/otterdog/webapp/templates/comment/automerge_problems.txt
@@ -1,0 +1,6 @@
+> [!WARNING]
+> This pull request cannot be merged by the author
+
+{% for problem in problems %}
+- problem
+{% endfor %}

--- a/otterdog/webapp/templates/comment/wrong_user_merge_comment.txt
+++ b/otterdog/webapp/templates/comment/wrong_user_merge_comment.txt
@@ -1,2 +1,0 @@
-> [!WARNING]
-> Only the author of the pull request, a project-lead or a member of the admin teams is allowed to auto-merge it.

--- a/otterdog/webapp/utils.py
+++ b/otterdog/webapp/utils.py
@@ -21,10 +21,11 @@ from quart_redis import get_redis  # type: ignore
 
 from otterdog.cache import get_github_cache
 from otterdog.config import OtterdogConfig
+from otterdog.credentials import Credentials
+from otterdog.providers.github import GitHubProvider
 from otterdog.providers.github.auth import app_auth, token_auth
 from otterdog.providers.github.cache.ghproxy import ghproxy_cache
 from otterdog.providers.github.cache.redis import redis_cache
-from otterdog.providers.github.graphql import GraphQLClient
 from otterdog.providers.github.rest import RestApi
 from otterdog.webapp.blueprints import Blueprint, read_blueprint
 from otterdog.webapp.policies import Policy, read_policy
@@ -106,14 +107,17 @@ def decode_bytes_dict(data: dict[bytes, bytes]) -> dict[str, str]:
     return {k.decode("utf-8"): v.decode("utf-8") for k, v in data.items()}
 
 
-async def get_rest_api_for_installation(installation_id: int) -> RestApi:
+async def get_github_provider_for_installation(installation_id: int) -> GitHubProvider:
     token, _ = await get_token_for_installation(installation_id)
-    return RestApi(token_auth(token), get_github_cache())
-
-
-async def get_graphql_api_for_installation(installation_id: int) -> GraphQLClient:
-    token, _ = await get_token_for_installation(installation_id)
-    return GraphQLClient(token_auth(token), get_github_cache())
+    return GitHubProvider(
+        Credentials(
+            _username=None,
+            _password=None,
+            _totp_secret=None,
+            _last_totp=None,
+            _github_token=token,
+        )
+    )
 
 
 def get_app_root_directory(app: Quart | None = None) -> str:

--- a/tests/providers/github/integration/test_pull_request.py
+++ b/tests/providers/github/integration/test_pull_request.py
@@ -1,0 +1,82 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from .conftest import GitHubProviderTestKit
+
+ORG_ID = "test-org"
+REPO_NAME = "test-repo"
+PR_NUMBER = 123
+
+
+def pull_request(github: GitHubProviderTestKit):
+    return github.provider.pull_request(ORG_ID, REPO_NAME, PR_NUMBER)
+
+
+async def test_get_data_returns_pull_request_payload(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/pulls/{PR_NUMBER}",
+        response_json={"number": PR_NUMBER, "state": "open"},
+    )
+
+    data = await pull_request(github).get_data()
+
+    assert data == {"number": PR_NUMBER, "state": "open"}
+
+
+async def test_request_reviews(github: GitHubProviderTestKit):
+    github.http.expect(
+        "POST",
+        f"/repos/{ORG_ID}/{REPO_NAME}/pulls/{PR_NUMBER}/requested_reviewers",
+        request_json={"reviewers": ["alice"], "team_reviewers": ["core"]},
+        response_status=201,
+        response_text="created",
+    )
+
+    result = await pull_request(github).request_reviews(reviewers=["alice"], team_reviewers=["core"])
+
+    assert result is True
+
+
+async def test_merge_pull_request_returns_api_response(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/pulls/{PR_NUMBER}/merge",
+        request_json={"merge_method": "squash"},
+        response_json={"merged": True, "sha": "1234"},
+    )
+
+    response = await pull_request(github).merge_pull_request("squash")
+
+    assert response == {"merged": True, "sha": "1234"}
+
+
+async def test_merge_rebase(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/pulls/{PR_NUMBER}/merge",
+        request_json={"merge_method": "rebase"},
+        response_json={"merged": True},
+    )
+
+    merged = await pull_request(github).merge(merge_method="rebase")
+
+    assert merged is True
+
+
+async def test_merge_squash(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/pulls/{PR_NUMBER}/merge",
+        request_json={"merge_method": "squash", "commit_message": "chore: merge"},
+        response_json={"merged": True},
+    )
+
+    merged = await pull_request(github).merge(commit_message="chore: merge", merge_method="squash")
+
+    assert merged is True


### PR DESCRIPTION
This pulls the `PullRequest` class one level up, so it can use the GraphQL API as well. New features that would benefit from this are not included in this PR. (The code is already there in different places, it's just not in the `PullRequest` class)

In order to achieve that, users like `InstallationBasedTask` must not use `rest_api` and `graphql_api` directly. They must use `GitHubProvider` abstraction level.

Hint: see individual commits for review. Unfurtunately quite a lot of code needed to be touched here.

⚠️  I was not able to test the webapp functionality. Ideally this is just refactoring, and absolutely no behavior change, But the last commit is a good example of stuff that mypy did not catch :(

Resolves #604

- This is draft, as I accidentally included #603 on the branch. Easiest would be to rebase once #603 is merged. --
