### PR TITLE
feat: add support for env_token_override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
  - Environment-based credential provider ([#593](https://github.com/eclipse-csi/otterdog/pull/593))
  - Auto-Comment on auto-merge problems ([#603](https://github.com/eclipse-csi/otterdog/pull/603))
- - Support for workflow setting `fork_pr_approval_policy` ([#576](https://github.com/eclipse-csi/otterdog/pull/576))
- - Added HashiCorp Vault credential provider support with hvac library integration ([#540](https://github.com/eclipse-csi/otterdog/pull/540))
+ - Add support for workflow setting `fork_pr_approval_policy` ([#576](https://github.com/eclipse-csi/otterdog/pull/576))
+ - Add HashiCorp Vault credential provider support with hvac library integration ([#540](https://github.com/eclipse-csi/otterdog/pull/540))
+ - Add support for setting `env_token_override` in otterdog config ([#392](https://github.com/eclipse-csi/otterdog/issues/392))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -227,3 +227,13 @@ As the `password_store_dir` might be different on different machines, you can al
   }
 }
 ```
+
+In case you want to explicitly use a different GitHub token for some operations, you can add an override e.g. in `.otterdog-defaults.json`:
+
+```json
+{
+  "env_token_override": "GH_TOKEN"
+}
+```
+
+In such a case, if an operation only needs a token, it will use the one extracted from the env variable of the given name.

--- a/otterdog/config.py
+++ b/otterdog/config.py
@@ -170,6 +170,15 @@ class CredentialResolver(SecretResolver):
         return provider
 
     def get_credentials(self, org_config: OrganizationConfig, only_token: bool = False) -> Credentials:
+        from .credentials import Credentials
+
+        if only_token and self._config.env_token_override is not None:
+            github_token = os.getenv(self._config.env_token_override)
+            if github_token is None:
+                raise RuntimeError("defaults.env_token_override set to a non-existent env variable")
+            else:
+                return Credentials(None, None, None, github_token)
+
         provider_type = org_config.credential_data.get("provider")
 
         if provider_type is None:
@@ -214,6 +223,7 @@ class OtterdogConfig:
     _github_config: Mapping[str, Any] = dataclasses.field(init=False)
     _default_credential_provider: str = dataclasses.field(init=False)
     _jsonnet_base_dir: str = dataclasses.field(init=False)
+    _env_token_override: str | None = dataclasses.field(init=False)
 
     _organizations_map: dict[str, OrganizationConfig] = dataclasses.field(init=False, default_factory=dict)
     _organizations: list[OrganizationConfig] = dataclasses.field(init=False, default_factory=list)
@@ -234,6 +244,10 @@ class OtterdogConfig:
         if not os.path.exists(self._jsonnet_base_dir):
             os.makedirs(self._jsonnet_base_dir)
 
+        object.__setattr__(
+            self, "_env_token_override", query_json("defaults.env_token_override", self.configuration) or None
+        )
+
         organizations = self.configuration.get("organizations", [])
         for org in (o for o in organizations if not o.get("archived", False)):
             org_config = OrganizationConfig.from_dict(org, self)
@@ -248,6 +262,10 @@ class OtterdogConfig:
     @property
     def jsonnet_base_dir(self) -> str:
         return self._jsonnet_base_dir
+
+    @property
+    def env_token_override(self) -> str | None:
+        return self._env_token_override
 
     @property
     def default_config_repo(self) -> str:


### PR DESCRIPTION
This fixes #392 .

You can specify now a new configuration value, e.g. in `.otterdog-defaults.json`:

```json
{
  "env_token_override": "GH_TOKEN",
}
```

so when running an operation that only needs a token, the one from the env variable as specified in the override will be used instead.