### PR TITLE
build: add dev tag for main for automatic staging deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ needs.release.outputs.release-tag }}
+          ref: ${{ needs.prepare.outputs.release-tag }}
 
       - name: "Log in to the Container registry"
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -86,11 +86,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            ${{ needs.prepare.outputs.release-version }}
+            type=semver,pattern={{version}}
+            type=raw,value=${{ needs.prepare.outputs.release-version }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=${{ needs.prepare.outputs.release-version }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
           labels: |
             org.opencontainers.image.version=${{ needs.prepare.outputs.release-version }}
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: "Build and push Docker image"
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
@@ -100,7 +103,7 @@ jobs:
           build-args: |
             version=${{ needs.prepare.outputs.project-version }}
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.release-version }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
   build-dist:


### PR DESCRIPTION
Publish images with 'dev' tag on main branch pushes to enable automatic staging environment updates. Keeps existing SNAPSHOT tags for backward compatibility.