### PR TITLE
Introduce OTTERDOG_CONFIG_ROOT to locate otterdog-configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
  - Add tests for workflow validation settings ([#633](https://github.com/eclipse-csi/otterdog/pull/633))
+ - Add support for `OTTERDOG_CONFIG_ROOT` environment variable ([#632](https://github.com/eclipse-csi/otterdog/pull/632))
 
 ## [1.3.0] - 30/03/2026
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,26 @@ However, when named `otterdog.jsonnet` or `otterdog.json`, the cli tool will aut
 > In this example the `plain` provider is being used to access credentials to avoid setting up a `real` credential provider (see below) for a quick setup.
 > However, the `plain` provider should *NOT* be used for anything else to avoid leakage of data in case the `otterdog.json` file is shared with other users.
 
+### Environment Variables
+
+#### OTTERDOG_CONFIG_ROOT
+
+The `OTTERDOG_CONFIG_ROOT` environment variable allows you to specify a custom root directory for Otterdog configuration files and organization data. E.g: https://github.com/EclipseFdn/otterdog-configs
+
+When set, Otterdog will:
+- Search for configuration files (`otterdog.jsonnet` or `otterdog.json`) in this directory
+- Use this directory as the base path for the `config_dir` (default: `orgs/`) containing organization configurations
+
+**Usage:**
+
+```bash
+# Set the configuration root directory
+export OTTERDOG_CONFIG_ROOT=/path/to/config
+
+# Run otterdog commands - will automatically use the specified directory
+otterdog fetch-config eclipse-csi
+otterdog apply eclipse-csi
+```
 ### Credentials
 
 Otterdog needs certain credentials to access information from an organization and its repositories on GitHub:

--- a/otterdog/cli.py
+++ b/otterdog/cli.py
@@ -33,8 +33,9 @@ _CONFIG: OtterdogConfig | None = None
 def load_otterdog_config(config_file_param: str | None, local_mode: bool) -> OtterdogConfig:
     if config_file_param:
         config_file = config_file_param
+        config_root = None
     else:
-        config_root = Path(os.environ.get("OTTERDOG_CONFIG_ROOT", "."))
+        config_root = Path(os.environ.get("OTTERDOG_CONFIG_ROOT", os.curdir))
 
         for file in _CONFIG_FILES:
             config_path = config_root / file
@@ -46,7 +47,7 @@ def load_otterdog_config(config_file_param: str | None, local_mode: bool) -> Ott
                 f'No configuration file specified, and default files "{_CONFIG_FILES}" not found in "{config_root}".'
             )
 
-    return OtterdogConfig.from_file(config_file, local_mode)
+    return OtterdogConfig.from_file(config_file, local_mode, str(config_root) if config_root else None)
 
 
 def complete_organizations(ctx, param, incomplete):

--- a/otterdog/cli.py
+++ b/otterdog/cli.py
@@ -7,6 +7,7 @@
 #  *******************************************************************************
 
 import asyncio
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -33,12 +34,17 @@ def load_otterdog_config(config_file_param: str | None, local_mode: bool) -> Ott
     if config_file_param:
         config_file = config_file_param
     else:
+        config_root = Path(os.environ.get("OTTERDOG_CONFIG_ROOT", "."))
+
         for file in _CONFIG_FILES:
-            if Path(file).exists():
-                config_file = file
+            config_path = config_root / file
+            if config_path.exists():
+                config_file = str(config_path)
                 break
         else:
-            raise RuntimeError(f"No configuration file specified, and default files {_CONFIG_FILES} not found.")
+            raise RuntimeError(
+                f'No configuration file specified, and default files "{_CONFIG_FILES}" not found in "{config_root}".'
+            )
 
     return OtterdogConfig.from_file(config_file, local_mode)
 

--- a/otterdog/config.py
+++ b/otterdog/config.py
@@ -226,10 +226,12 @@ class OtterdogConfig:
             self, "_default_credential_provider", query_json("defaults.credentials.provider", self.configuration) or ""
         )
 
+        config_root = os.environ.get("OTTERDOG_CONFIG_ROOT", self.working_dir)
+        config_dir = self._jsonnet_config.get("config_dir", "orgs")
         object.__setattr__(
             self,
             "_jsonnet_base_dir",
-            os.path.join(self.working_dir, self._jsonnet_config.get("config_dir", "orgs")),
+            os.path.join(config_root, config_dir),
         )
         if not os.path.exists(self._jsonnet_base_dir):
             os.makedirs(self._jsonnet_base_dir)

--- a/otterdog/config.py
+++ b/otterdog/config.py
@@ -226,12 +226,10 @@ class OtterdogConfig:
             self, "_default_credential_provider", query_json("defaults.credentials.provider", self.configuration) or ""
         )
 
-        config_root = os.environ.get("OTTERDOG_CONFIG_ROOT", self.working_dir)
-        config_dir = self._jsonnet_config.get("config_dir", "orgs")
         object.__setattr__(
             self,
             "_jsonnet_base_dir",
-            os.path.join(config_root, config_dir),
+            os.path.join(self.working_dir, self._jsonnet_config.get("config_dir", "orgs")),
         )
         if not os.path.exists(self._jsonnet_base_dir):
             os.makedirs(self._jsonnet_base_dir)


### PR DESCRIPTION
The `OTTERDOG_CONFIG_ROOT` environment variable allows you to specify a custom root directory for Otterdog configuration files and organization data. E.g: https://github.com/EclipseFdn/otterdog-configs

It can be use from everywhere and not only from the otterdog-configs project. 

```bash
# Set the configuration root directory
export OTTERDOG_CONFIG_ROOT=/path/to/otterdog-configs

# Run otterdog commands - will automatically use the specified directory
otterdog fetch-config eclipse-csi
otterdog apply eclipse-csi
```