### PR TITLE
feat(org): add support for code security configurations

### DIFF
--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -209,6 +209,25 @@ local newOrgRuleset(name) = newRepoRuleset(name) {
   protect_repo_names: false,
 };
 
+# Function to create a new organization code security configuration with default settings.
+local newOrgCodeSecurityConfiguration(name) = {
+  name: name,
+  description: "",
+  advanced_security: "disabled",
+  dependency_graph: "enabled",
+  dependency_graph_autosubmit_action: "not_set",
+  dependabot_alerts: "disabled",
+  dependabot_security_updates: "disabled",
+  code_scanning_default_setup: "disabled",
+  secret_scanning: "disabled",
+  secret_scanning_push_protection: "disabled",
+  secret_scanning_delegated_bypass: "disabled",
+  secret_scanning_validity_checks: "disabled",
+  secret_scanning_non_provider_patterns: "disabled",
+  private_vulnerability_reporting: "disabled",
+  enforcement: "enforced",
+};
+
 # Function to create a new organization webhook with default settings.
 local newOrgWebhook(url) = {
   active: true,
@@ -408,6 +427,9 @@ local newOrg(name, id=name) = {
   # organization rulesets
   rulesets: [],
 
+  # organization code security configurations
+  code_security_configurations: [],
+
   # List of repositories of the organization.
   # Entries here can be extended during template manifestation:
   #  * new repos should be defined using the newRepo template
@@ -428,6 +450,7 @@ local newOrg(name, id=name) = {
   newOrgSecret:: newOrgSecret,
   newOrgVariable:: newOrgVariable,
   newOrgRuleset:: newOrgRuleset,
+  newOrgCodeSecurityConfiguration:: newOrgCodeSecurityConfiguration,
   newCustomProperty:: newCustomProperty,
   newRepo:: newRepo,
   extendRepo:: extendRepo,

--- a/otterdog/jsonnet.py
+++ b/otterdog/jsonnet.py
@@ -34,6 +34,7 @@ class JsonnetConfig:
     create_org_secret = "newOrgSecret"
     create_org_variable = "newOrgVariable"
     create_org_ruleset = "newOrgRuleset"
+    create_org_code_security_configuration = "newOrgCodeSecurityConfiguration"
     create_repo = "newRepo"
     extend_repo = "extendRepo"
     create_repo_webhook = "newRepoWebhook"
@@ -74,6 +75,7 @@ class JsonnetConfig:
         self._default_org_secret_config: dict[str, Any] | None = None
         self._default_org_variable_config: dict[str, Any] | None = None
         self._default_org_ruleset_config: dict[str, Any] | None = None
+        self._default_org_code_security_configuration_config: dict[str, Any] | None = None
         self._default_repo_config: dict[str, Any] | None = None
         self._default_repo_webhook_config: dict[str, Any] | None = None
         self._default_repo_secret_config: dict[str, Any] | None = None
@@ -187,6 +189,16 @@ class JsonnetConfig:
             return jsonnet_evaluate_snippet(org_ruleset_snippet)
         except RuntimeError:
             _logger.debug("no default org ruleset config found, rulesets will be skipped")
+            return None
+
+    @cached_property
+    def default_org_code_security_configuration_config(self):
+        try:
+            # load the default org code security configuration config
+            snippet = f"(import '{self.template_file}').{self.create_org_code_security_configuration}('default')"
+            return jsonnet_evaluate_snippet(snippet)
+        except RuntimeError:
+            _logger.debug("no default org code security configuration config found, configurations will be skipped")
             return None
 
     @cached_property

--- a/otterdog/models/github_organization.py
+++ b/otterdog/models/github_organization.py
@@ -32,6 +32,7 @@ from otterdog.models import (
 from otterdog.models.branch_protection_rule import BranchProtectionRule
 from otterdog.models.custom_property import CustomProperty
 from otterdog.models.environment import Environment
+from otterdog.models.organization_code_security_configuration import OrganizationCodeSecurityConfiguration
 from otterdog.models.organization_role import OrganizationRole
 from otterdog.models.organization_ruleset import OrganizationRuleset
 from otterdog.models.organization_secret import OrganizationSecret
@@ -75,6 +76,7 @@ class GitHubOrganization:
     secrets: list[OrganizationSecret] = dataclasses.field(default_factory=list)
     variables: list[OrganizationVariable] = dataclasses.field(default_factory=list)
     rulesets: list[OrganizationRuleset] = dataclasses.field(default_factory=list)
+    code_security_configurations: list[OrganizationCodeSecurityConfiguration] = dataclasses.field(default_factory=list)
     repositories: list[Repository] = dataclasses.field(default_factory=list)
 
     _secrets_resolved: bool = False
@@ -136,6 +138,15 @@ class GitHubOrganization:
 
     def set_rulesets(self, rulesets: list[OrganizationRuleset]) -> None:
         self.rulesets = rulesets
+
+    def add_code_security_configuration(self, configuration: OrganizationCodeSecurityConfiguration) -> None:
+        self.code_security_configurations.append(configuration)
+
+    def get_code_security_configuration(self, name: str) -> OrganizationCodeSecurityConfiguration | None:
+        return next(filter(lambda x: x.name == name, self.code_security_configurations), None)  # type: ignore
+
+    def set_code_security_configurations(self, configurations: list[OrganizationCodeSecurityConfiguration]) -> None:
+        self.code_security_configurations = configurations
 
     def add_repository(self, repo: Repository) -> None:
         self.repositories.append(repo)
@@ -205,6 +216,9 @@ class GitHubOrganization:
             for ruleset in self.rulesets:
                 ruleset.validate(context, self)
 
+        for configuration in self.code_security_configurations:
+            configuration.validate(context, self)
+
         # Run synchronous validations and collect repos needing API codescaning validation
         repos_needing_codescaning_language_validation = []
         for repo in self.repositories:
@@ -271,6 +285,10 @@ class GitHubOrganization:
             yield ruleset, None
             yield from ruleset.get_model_objects()
 
+        for configuration in self.code_security_configurations:
+            yield configuration, None
+            yield from configuration.get_model_objects()
+
         for repo in self.repositories:
             yield repo, None
             yield from repo.get_model_objects()
@@ -291,6 +309,8 @@ class GitHubOrganization:
             "variables": OptionalS("variables", default=[])
             >> Forall(lambda x: OrganizationVariable.from_model_data(x)),
             "rulesets": OptionalS("rulesets", default=[]) >> Forall(lambda x: OrganizationRuleset.from_model_data(x)),
+            "code_security_configurations": OptionalS("code_security_configurations", default=[])
+            >> Forall(lambda x: OrganizationCodeSecurityConfiguration.from_model_data(x)),
             "repositories": OptionalS("repositories", default=[]) >> Forall(lambda x: Repository.from_model_data(x)),
         }
 
@@ -438,6 +458,21 @@ class GitHubOrganization:
             printer.level_down()
             printer.println("],")
 
+        # print organization code security configurations
+        if len(self.code_security_configurations) > 0:
+            default_configuration = OrganizationCodeSecurityConfiguration.from_model_data(
+                config.default_org_code_security_configuration_config
+            )
+
+            printer.println("code_security_configurations+: [")
+            printer.level_up()
+
+            for configuration in self.code_security_configurations:
+                configuration.to_jsonnet(printer, config, context, False, default_configuration)
+
+            printer.level_down()
+            printer.println("],")
+
         # print repositories
         if len(self.repositories) > 0:
             repos_by_name = associate_by_key(self.repositories, lambda x: x.name)
@@ -488,6 +523,13 @@ class GitHubOrganization:
         )
         OrganizationRuleset.generate_live_patch_of_list(
             self.rulesets, current_organization.rulesets, None, context, handler
+        )
+        OrganizationCodeSecurityConfiguration.generate_live_patch_of_list(
+            self.code_security_configurations,
+            current_organization.code_security_configurations,
+            None,
+            context,
+            handler,
         )
         Repository.generate_live_patch_of_list(
             self.repositories, current_organization.repositories, None, context, handler
@@ -637,6 +679,17 @@ class GitHubOrganization:
             else:
                 _logger.debug("not reading org secrets, no default config available")
 
+        @debug_times("code_security_configurations")
+        async def _load_code_security_configurations() -> None:
+            if jsonnet_config.default_org_code_security_configuration_config is not None:
+                github_configurations = await provider.get_org_code_security_configurations(github_id)
+                for configuration in github_configurations:
+                    org.add_code_security_configuration(
+                        OrganizationCodeSecurityConfiguration.from_provider_data(github_id, configuration)
+                    )
+            else:
+                _logger.debug("not reading org code security configurations, no default config available")
+
         @debug_times("repos")
         async def _load_repos() -> None:
             if jsonnet_config.default_repo_config is not None:
@@ -660,6 +713,7 @@ class GitHubOrganization:
             task_group.soonify(_load_secrets)()
             task_group.soonify(_load_variables)()
             task_group.soonify(_load_rulesets)()
+            task_group.soonify(_load_code_security_configurations)()
             task_group.soonify(_load_repos)()
 
         return org

--- a/otterdog/models/organization_code_security_configuration.py
+++ b/otterdog/models/organization_code_security_configuration.py
@@ -1,0 +1,123 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
+from otterdog.models import (
+    FailureType,
+    LivePatch,
+    LivePatchType,
+    ModelObject,
+    ValidationContext,
+)
+from otterdog.utils import is_set_and_valid, unwrap
+
+if TYPE_CHECKING:
+    from otterdog.jsonnet import JsonnetConfig
+    from otterdog.providers.github import GitHubProvider
+
+
+_FEATURE_VALUES = {"enabled", "disabled", "not_set"}
+_ENFORCEMENT_VALUES = {"enforced", "unenforced"}
+
+
+@dataclasses.dataclass
+class OrganizationCodeSecurityConfiguration(ModelObject):
+    """
+    Represents a Code Security Configuration defined on organization level.
+    """
+
+    id: int = dataclasses.field(metadata={"external_only": True})
+    name: str = dataclasses.field(metadata={"key": True})
+    description: str
+    advanced_security: str
+    dependency_graph: str
+    dependency_graph_autosubmit_action: str
+    dependabot_alerts: str
+    dependabot_security_updates: str
+    code_scanning_default_setup: str
+    secret_scanning: str
+    secret_scanning_push_protection: str
+    secret_scanning_delegated_bypass: str
+    secret_scanning_validity_checks: str
+    secret_scanning_non_provider_patterns: str
+    private_vulnerability_reporting: str
+    enforcement: str
+
+    @property
+    def model_object_name(self) -> str:
+        return "org_code_security_configuration"
+
+    def validate(self, context: ValidationContext, parent_object: Any) -> None:
+        feature_fields = (
+            "advanced_security",
+            "dependency_graph",
+            "dependency_graph_autosubmit_action",
+            "dependabot_alerts",
+            "dependabot_security_updates",
+            "code_scanning_default_setup",
+            "secret_scanning",
+            "secret_scanning_push_protection",
+            "secret_scanning_delegated_bypass",
+            "secret_scanning_validity_checks",
+            "secret_scanning_non_provider_patterns",
+            "private_vulnerability_reporting",
+        )
+
+        for field_name in feature_fields:
+            value = getattr(self, field_name)
+            if is_set_and_valid(value) and value not in _FEATURE_VALUES:
+                context.add_failure(
+                    FailureType.ERROR,
+                    f"{self.get_model_header(parent_object)} has '{field_name}' of value '{value}', "
+                    f"while only values ('enabled' | 'disabled' | 'not_set') are allowed.",
+                )
+
+        if is_set_and_valid(self.enforcement) and self.enforcement not in _ENFORCEMENT_VALUES:
+            context.add_failure(
+                FailureType.ERROR,
+                f"{self.get_model_header(parent_object)} has 'enforcement' of value '{self.enforcement}', "
+                f"while only values ('enforced' | 'unenforced') are allowed.",
+            )
+
+    def get_jsonnet_template_function(self, jsonnet_config: JsonnetConfig, extend: bool) -> str | None:
+        return f"orgs.{jsonnet_config.create_org_code_security_configuration}"
+
+    @classmethod
+    async def apply_live_patch(
+        cls,
+        patch: LivePatch[OrganizationCodeSecurityConfiguration],
+        org_id: str,
+        provider: GitHubProvider,
+    ) -> None:
+        match patch.patch_type:
+            case LivePatchType.ADD:
+                await provider.add_org_code_security_configuration(
+                    org_id,
+                    await unwrap(patch.expected_object).to_provider_data(org_id, provider),
+                )
+
+            case LivePatchType.REMOVE:
+                current_object = unwrap(patch.current_object)
+                await provider.delete_org_code_security_configuration(
+                    org_id,
+                    current_object.id,
+                    current_object.name,
+                )
+
+            case LivePatchType.CHANGE:
+                current_object = unwrap(patch.current_object)
+                await provider.update_org_code_security_configuration(
+                    org_id,
+                    current_object.id,
+                    current_object.name,
+                    await unwrap(patch.expected_object).to_provider_data(org_id, provider),
+                )

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -160,6 +160,35 @@ class GitHubProvider:
     async def delete_org_custom_role(self, org_id: str, role_id: int, role_name: str) -> None:
         await self.rest_api.org.delete_custom_role(org_id, role_id, role_name)
 
+    async def get_org_code_security_configurations(self, org_id: str) -> list[dict[str, Any]]:
+        return await self.rest_api.org.get_code_security_configurations(org_id)
+
+    async def add_org_code_security_configuration(self, org_id: str, data: dict[str, Any]) -> None:
+        await self.rest_api.org.add_code_security_configuration(org_id, data)
+
+    async def update_org_code_security_configuration(
+        self, org_id: str, configuration_id: int, name: str, data: dict[str, Any]
+    ) -> None:
+        if len(data) > 0:
+            if configuration_id <= 0:
+                resolved_id = await self.rest_api.org.get_code_security_configuration_id(org_id, name)
+                if resolved_id is None:
+                    raise RuntimeError(
+                        f"failed to find code security configuration with name '{name}' in org '{org_id}'"
+                    )
+                configuration_id = resolved_id
+
+            await self.rest_api.org.update_code_security_configuration(org_id, configuration_id, name, data)
+
+    async def delete_org_code_security_configuration(self, org_id: str, configuration_id: int, name: str) -> None:
+        if configuration_id <= 0:
+            resolved_id = await self.rest_api.org.get_code_security_configuration_id(org_id, name)
+            if resolved_id is None:
+                raise RuntimeError(f"failed to find code security configuration with name '{name}' in org '{org_id}'")
+            configuration_id = resolved_id
+
+        await self.rest_api.org.delete_code_security_configuration(org_id, configuration_id, name)
+
     async def get_org_teams(self, org_id: str) -> list[dict[str, Any]]:
         return await self.rest_api.team.get_teams(org_id)
 

--- a/otterdog/providers/github/rest/org_client.py
+++ b/otterdog/providers/github/rest/org_client.py
@@ -208,6 +208,61 @@ class OrgClient(RestClient):
 
         _logger.debug("removed org role with name '%s'", role_name)
 
+    async def get_code_security_configurations(self, org_id: str) -> list[dict[str, Any]]:
+        _logger.debug("retrieving code security configurations for org '%s'", org_id)
+
+        try:
+            result = await self.requester.request_json("GET", f"/orgs/{org_id}/code-security/configurations")
+            # filter out predefined configurations (e.g. GitHub recommended) which are managed by GitHub
+            return [c for c in result if c.get("target_type") != "global"]
+        except GitHubException as ex:
+            raise RuntimeError(f"failed retrieving code security configurations for org '{org_id}':\n{ex}") from ex
+
+    async def get_code_security_configuration_id(self, org_id: str, name: str) -> int | None:
+        _logger.debug("retrieving id for code security configuration with name '%s' in org '%s'", name, org_id)
+
+        configurations = await self.get_code_security_configurations(org_id)
+        for configuration in configurations:
+            if configuration["name"] == name:
+                return configuration["id"]
+
+        return None
+
+    async def add_code_security_configuration(self, org_id: str, data: dict[str, Any]) -> None:
+        name = data.get("name", "<unknown>")
+        _logger.debug("adding code security configuration with name '%s' for org '%s'", name, org_id)
+
+        try:
+            await self.requester.request_json("POST", f"/orgs/{org_id}/code-security/configurations", data)
+            _logger.debug("added code security configuration with name '%s'", name)
+        except GitHubException as ex:
+            raise RuntimeError(f"failed to add code security configuration with name '{name}':\n{ex}") from ex
+
+    async def update_code_security_configuration(
+        self, org_id: str, configuration_id: int, name: str, data: dict[str, Any]
+    ) -> None:
+        _logger.debug("updating code security configuration with name '%s' for org '%s'", name, org_id)
+
+        try:
+            await self.requester.request_json(
+                "PATCH", f"/orgs/{org_id}/code-security/configurations/{configuration_id}", data
+            )
+            _logger.debug("updated code security configuration with name '%s'", name)
+        except GitHubException as ex:
+            raise RuntimeError(f"failed to update code security configuration with name '{name}':\n{ex}") from ex
+
+    async def delete_code_security_configuration(self, org_id: str, configuration_id: int, name: str) -> None:
+        _logger.debug("deleting code security configuration with name '%s' for org '%s'", name, org_id)
+
+        status, _ = await self.requester.request_raw(
+            "DELETE", f"/orgs/{org_id}/code-security/configurations/{configuration_id}"
+        )
+
+        if status != 204:
+            raise RuntimeError(f"failed to delete code security configuration with name '{name}'")
+
+        _logger.debug("removed code security configuration with name '%s'", name)
+
     async def get_custom_properties(self, org_id: str) -> list[dict[str, Any]]:
         _logger.debug("retrieving custom properties for org '%s'", org_id)
 

--- a/otterdog/resources/schemas/org-code-security-configuration.json
+++ b/otterdog/resources/schemas/org-code-security-configuration.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "advanced_security": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "dependency_graph": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "dependency_graph_autosubmit_action": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "dependabot_alerts": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "dependabot_security_updates": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "code_scanning_default_setup": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "secret_scanning": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "secret_scanning_push_protection": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "secret_scanning_delegated_bypass": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "secret_scanning_validity_checks": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "secret_scanning_non_provider_patterns": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "private_vulnerability_reporting": { "type": "string", "enum": ["enabled", "disabled", "not_set"] },
+    "enforcement": { "type": "string", "enum": ["enforced", "unenforced"] }
+  },
+
+  "required": [ "name" ],
+  "additionalProperties": false
+}

--- a/otterdog/resources/schemas/organization.json
+++ b/otterdog/resources/schemas/organization.json
@@ -30,6 +30,10 @@
       "type": "array",
       "items": { "$ref": "org-ruleset.json" }
     },
+    "code_security_configurations": {
+      "type": "array",
+      "items": { "$ref": "org-code-security-configuration.json" }
+    },
     "repositories": {
       "type": "array",
       "items": { "$ref": "repository.json" }

--- a/tests/models/resources/github-org-code-security-configuration.json
+++ b/tests/models/resources/github-org-code-security-configuration.json
@@ -1,0 +1,23 @@
+{
+  "id": 42,
+  "target_type": "organization",
+  "name": "my-config",
+  "description": "My code security configuration",
+  "advanced_security": "enabled",
+  "dependency_graph": "enabled",
+  "dependency_graph_autosubmit_action": "enabled",
+  "dependabot_alerts": "enabled",
+  "dependabot_security_updates": "enabled",
+  "code_scanning_default_setup": "enabled",
+  "secret_scanning": "enabled",
+  "secret_scanning_push_protection": "enabled",
+  "secret_scanning_delegated_bypass": "disabled",
+  "secret_scanning_validity_checks": "enabled",
+  "secret_scanning_non_provider_patterns": "enabled",
+  "private_vulnerability_reporting": "enabled",
+  "enforcement": "enforced",
+  "url": "https://api.github.com/orgs/octo-org/code-security/configurations/42",
+  "html_url": "https://github.com/organizations/octo-org/settings/security_products/configurations/42",
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}

--- a/tests/models/resources/otterdog-org-code-security-configuration.json
+++ b/tests/models/resources/otterdog-org-code-security-configuration.json
@@ -1,0 +1,17 @@
+{
+  "name": "my-config",
+  "description": "My code security configuration",
+  "advanced_security": "enabled",
+  "dependency_graph": "enabled",
+  "dependency_graph_autosubmit_action": "enabled",
+  "dependabot_alerts": "enabled",
+  "dependabot_security_updates": "enabled",
+  "code_scanning_default_setup": "enabled",
+  "secret_scanning": "enabled",
+  "secret_scanning_push_protection": "enabled",
+  "secret_scanning_delegated_bypass": "disabled",
+  "secret_scanning_validity_checks": "enabled",
+  "secret_scanning_non_provider_patterns": "enabled",
+  "private_vulnerability_reporting": "enabled",
+  "enforcement": "enforced"
+}

--- a/tests/models/test_org_code_security_configuration.py
+++ b/tests/models/test_org_code_security_configuration.py
@@ -1,0 +1,75 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from collections.abc import Mapping
+from typing import Any
+
+from otterdog.jsonnet import JsonnetConfig
+from otterdog.models import ModelObject
+from otterdog.models.organization_code_security_configuration import (
+    OrganizationCodeSecurityConfiguration,
+)
+from otterdog.utils import UNSET
+
+from . import ModelTest
+
+
+class OrganizationCodeSecurityConfigurationTest(ModelTest):
+    def create_model(self, data: Mapping[str, Any]) -> ModelObject:
+        return OrganizationCodeSecurityConfiguration.from_model_data(data)
+
+    @property
+    def template_function(self) -> str:
+        return JsonnetConfig.create_org_code_security_configuration
+
+    @property
+    def model_data(self):
+        return self.load_json_resource("otterdog-org-code-security-configuration.json")
+
+    @property
+    def provider_data(self):
+        return self.load_json_resource("github-org-code-security-configuration.json")
+
+    def test_load_from_model(self):
+        configuration = OrganizationCodeSecurityConfiguration.from_model_data(self.model_data)
+
+        assert configuration.id is UNSET
+        assert configuration.name == "my-config"
+        assert configuration.description == "My code security configuration"
+        assert configuration.advanced_security == "enabled"
+        assert configuration.dependency_graph == "enabled"
+        assert configuration.dependency_graph_autosubmit_action == "enabled"
+        assert configuration.dependabot_alerts == "enabled"
+        assert configuration.dependabot_security_updates == "enabled"
+        assert configuration.code_scanning_default_setup == "enabled"
+        assert configuration.secret_scanning == "enabled"
+        assert configuration.secret_scanning_push_protection == "enabled"
+        assert configuration.secret_scanning_delegated_bypass == "disabled"
+        assert configuration.secret_scanning_validity_checks == "enabled"
+        assert configuration.secret_scanning_non_provider_patterns == "enabled"
+        assert configuration.private_vulnerability_reporting == "enabled"
+        assert configuration.enforcement == "enforced"
+
+    def test_load_from_provider(self):
+        configuration = OrganizationCodeSecurityConfiguration.from_provider_data(self.org_id, self.provider_data)
+
+        assert configuration.id == 42
+        assert configuration.name == "my-config"
+        assert configuration.description == "My code security configuration"
+        assert configuration.advanced_security == "enabled"
+        assert configuration.enforcement == "enforced"
+
+    async def test_to_provider(self):
+        configuration = OrganizationCodeSecurityConfiguration.from_model_data(self.model_data)
+
+        provider_data = await configuration.to_provider_data(self.org_id, self.provider)
+
+        assert "id" not in provider_data
+        assert provider_data["name"] == "my-config"
+        assert provider_data["advanced_security"] == "enabled"
+        assert provider_data["enforcement"] == "enforced"


### PR DESCRIPTION
## Summary

Adds a new org-level resource `OrganizationCodeSecurityConfiguration` that wraps GitHub's [Code Security Configurations API](https://docs.github.com/en/rest/code-security/configurations) (`/orgs/{org}/code-security/configurations`).

This is the successor to the deprecated per-feature `*_enabled_for_new_repositories` organization settings, letting users manage named code security configurations directly from otterdog.

## New resource

Each `code_security_configuration` entry supports:

- `name`, `description`, `enforcement`
- `advanced_security`
- `dependency_graph` + `dependency_graph_autosubmit_action`
- `dependabot_alerts`, `dependabot_security_updates`
- `code_scanning_default_setup`
- `secret_scanning` + `secret_scanning_push_protection`, `secret_scanning_delegated_bypass`, `secret_scanning_validity_checks`, `secret_scanning_non_provider_patterns`
- `private_vulnerability_reporting`

Feature fields accept `enabled` / `disabled` / `not_set`; `enforcement` accepts `enforced` / `unenforced`.

## Example

```jsonnet
orgs.newOrg('my-project', 'my-org') {
  code_security_configurations+: [
    orgs.newOrgCodeSecurityConfiguration('baseline') {
      description: 'Baseline configuration for all new repositories',
      advanced_security: 'enabled',
      secret_scanning: 'enabled',
      secret_scanning_push_protection: 'enabled',
      dependabot_alerts: 'enabled',
      dependabot_security_updates: 'enabled',
    },
  ],
}
```

## Changes

- `otterdog/models/organization_code_security_configuration.py` (new) — `ModelObject` with validate and full live-patch ADD/REMOVE/CHANGE support.
- `otterdog/models/github_organization.py` — new field, accessors, wiring into `get_model_objects`, `from_model_data`, `validate`, `to_jsonnet`, `generate_live_patch`, and parallel loading from provider.
- `otterdog/providers/github/__init__.py` + `otterdog/providers/github/rest/org_client.py` — list/add/update/delete methods for the new endpoints (global/predefined configs are filtered out on read).
- `otterdog/jsonnet.py` — `create_org_code_security_configuration` function name and `default_org_code_security_configuration_config` cached property.
- `examples/template/otterdog-defaults.libsonnet` — `newOrgCodeSecurityConfiguration()` helper, new `code_security_configurations` array on `newOrg`, and export.
- `otterdog/resources/schemas/org-code-security-configuration.json` (new) + `organization.json` reference.
- `tests/models/test_org_code_security_configuration.py` + fixture JSON files.

## Testing

- `poetry run pytest tests/models/test_org_code_security_configuration.py` → 4 passed
- `poetry run pytest tests/` → 247 passed, 2 skipped, 0 failures
- `poetry run mypy otterdog` → clean
- `poetry run ruff check` / `ruff format` → clean