### PR TITLE
feat(environment): add prevent_self_review support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [Unreleased]
+
+### Added
+
+ - Add support for `prevent_self_review` on environments ([#641](https://github.com/eclipse-csi/otterdog/issues/641))
+
 ## [1.3.4] - 29/06/2026
 
 ### Fixed

--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -271,6 +271,7 @@ local newEnvironment(name) = {
   name: name,
   wait_timer: 0,
   reviewers: [],
+  prevent_self_review: false,
   # Can be one of: all, protected_branches, branch_policies
   deployment_branch_policy: "all",
   branch_policies: [],

--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -274,6 +274,7 @@ local newEnvironment(name) = {
   name: name,
   wait_timer: 0,
   reviewers: [],
+  prevent_self_review: false,
   # Can be one of: all, protected_branches, branch_policies
   deployment_branch_policy: "all",
   branch_policies: [],

--- a/otterdog/models/environment.py
+++ b/otterdog/models/environment.py
@@ -38,6 +38,7 @@ class Environment(ModelObject):
     name: str = dataclasses.field(metadata={"key": True})
     wait_timer: int
     reviewers: list[str]
+    prevent_self_review: bool
     deployment_branch_policy: str
     branch_policies: list[str]
 

--- a/otterdog/models/environment.py
+++ b/otterdog/models/environment.py
@@ -54,6 +54,15 @@ class Environment(ModelObject):
                 f"outside of supported range (0, 43200).",
             )
 
+        if is_set_and_valid(self.reviewers):
+            if len(self.reviewers) == 0 and self.prevent_self_review is True:
+                context.add_failure(
+                    FailureType.WARNING,
+                    f"{self.get_model_header(parent_object)} has 'prevent_self_review' set to "
+                    f"'{self.prevent_self_review}', "
+                    f"but 'reviewers' is empty, setting will be ignored.",
+                )
+
         if is_set_and_valid(self.deployment_branch_policy):
             if self.deployment_branch_policy not in {"all", "protected", "selected"}:
                 context.add_failure(
@@ -142,6 +151,10 @@ class Environment(ModelObject):
                 >> OptionalS(0, default={})
                 >> OptionalS("reviewers", default=[])
                 >> Forall(lambda x: transform_reviewers(x)),
+                "prevent_self_review": OptionalS("protection_rules", default=[])
+                >> Filter(lambda obj: obj.get("type") == "required_reviewers")
+                >> OptionalS(0, default={})
+                >> OptionalS("prevent_self_review", default=False),
                 "deployment_branch_policy": OptionalS("deployment_branch_policy") >> F(transform_policy),
                 "branch_policies": OptionalS("branch_policies", default=[]) >> Forall(transform_branch_policy),
             }

--- a/otterdog/resources/schemas/environment.json
+++ b/otterdog/resources/schemas/environment.json
@@ -9,6 +9,7 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "prevent_self_review": { "type": "boolean" },
     "deployment_branch_policy": { "type": "string" },
     "branch_policies": {
       "type": "array",

--- a/tests/models/resources/github-environment.json
+++ b/tests/models/resources/github-environment.json
@@ -7,6 +7,7 @@
   "created_at": "2023-06-13T20:40:38Z",
   "updated_at": "2023-06-21T11:58:31Z",
   "can_admins_bypass": true,
+  "prevent_self_review": true,
   "protection_rules": [
     {
       "id": 9174563,

--- a/tests/models/resources/github-environment.json
+++ b/tests/models/resources/github-environment.json
@@ -12,6 +12,7 @@
     {
       "id": 9174563,
       "node_id": "GA_kwDOI9xAhM4Ai_4j",
+      "prevent_self_review": true,
       "type": "required_reviewers",
       "reviewers": [
         {

--- a/tests/models/resources/otterdog-environment.json
+++ b/tests/models/resources/otterdog-environment.json
@@ -5,6 +5,7 @@
     "@netomi",
     "@OtterdogTest/eclipsefdn-security"
   ],
+  "prevent_self_review": true,
   "deployment_branch_policy": "selected",
   "branch_policies": [
     "main",

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -41,6 +41,7 @@ class EnvironmentTest(ModelTest):
         assert env.name == "linux"
         assert env.wait_timer == 15
         assert env.reviewers == ["@netomi", "@OtterdogTest/eclipsefdn-security"]
+        assert env.prevent_self_review is True
         assert env.deployment_branch_policy == "selected"
         assert env.branch_policies == ["main", "develop/*"]
 
@@ -52,6 +53,7 @@ class EnvironmentTest(ModelTest):
         assert env.name == "linux"
         assert env.wait_timer == 15
         assert env.reviewers == ["@netomi", "@OtterdogTest/eclipsefdn-security"]
+        assert env.prevent_self_review is True
         assert env.deployment_branch_policy == "selected"
         assert env.branch_policies == ["main", "develop/*"]
 
@@ -60,8 +62,9 @@ class EnvironmentTest(ModelTest):
 
         provider_data = await env.to_provider_data(self.org_id, self.provider)
 
-        assert len(provider_data) == 5
+        assert len(provider_data) == 6
         assert provider_data["wait_timer"] == 15
+        assert provider_data["prevent_self_review"] is True
 
         assert query_json("reviewers[0].id", provider_data) == "id_netomi"
         assert query_json("reviewers[1].id", provider_data) == "id_OtterdogTest/eclipsefdn-security"


### PR DESCRIPTION
## Summary

Adds support for the `prevent_self_review` setting on deployment environments.

When enabled, this prevents the user who triggered a deployment from being able to approve their own deployment when required reviewers are configured — a common compliance requirement for production environments.

## API

The field is a top-level boolean on GitHub's [Environment API](https://docs.github.com/en/rest/deployments/environments#create-or-update-an-environment) payload (`prevent_self_review`), so it flows through otterdog's default from/to provider mappings without any extra transformation logic.

## Example

```jsonnet
environments+: [
  orgs.newEnvironment('production') {
    reviewers+: ['@my-org/platform-team'],
    prevent_self_review: true,
  },
],
```

## Changes

- `otterdog/models/environment.py` — new `prevent_self_review: bool` field.
- `examples/template/otterdog-defaults.libsonnet` — default `prevent_self_review: false` on `newEnvironment`.
- `otterdog/resources/schemas/environment.json` — new boolean property.
- `tests/models/test_environment.py` + `github-environment.json` + `otterdog-environment.json` — updated to cover the new field.

## Follow-ups (not in this PR)

Custom GitHub App deployment protection rules (managed via `/repos/{owner}/{repo}/environments/{env}/deployment_protection_rules`) require separate endpoints and a more complex model. Intentionally left as a separate change.

## Testing

- `poetry run pytest tests/` → 243 passed, 2 skipped, 0 failures
- `poetry run mypy otterdog` → clean
- `poetry run ruff check` / `ruff format --check` → clean