### PR TITLE
feat(custom-property): add values_editable_by support

### DIFF
--- a/docs/reference/organization/custom-property.md
+++ b/docs/reference/organization/custom-property.md
@@ -8,6 +8,7 @@ Definition of a `Custom Property` on organization level, the following propertie
 | _default_value_   | string or list[string] or null | The default value to assign to a repository if the property is required        |                                                           |
 | _description_     | string or null                 | A description of this property                                                 |                                                           |
 | _allowed_values_  | list[string] or null           | The list of allowed values if either `single_select` or `multi_select` is used |                                                           |
+| _values_editable_by_ | string or null              | Who can edit the values of this property on a repository                       | `org_actors`, `org_and_repo_actors` or `null`             |
 
 !!! note
 

--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -284,6 +284,7 @@ local newCustomProperty(name) = {
   default_value: null,
   description: null,
   allowed_values: [],
+  values_editable_by: null,
 };
 
 # Function to create a new organization with default settings.

--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -296,6 +296,7 @@ local newCustomProperty(name) = {
   default_value: null,
   description: null,
   allowed_values: [],
+  values_editable_by: null,
 };
 
 # Function to create a new organization with default settings.

--- a/otterdog/models/custom_property.py
+++ b/otterdog/models/custom_property.py
@@ -41,6 +41,7 @@ class CustomProperty(ModelObject):
     default_value: str | list[str] | None
     description: str | None
     allowed_values: list[str] | None
+    values_editable_by: str | None
 
     @property
     def model_object_name(self) -> str:
@@ -127,6 +128,17 @@ class CustomProperty(ModelObject):
                             f"'{self.default_value}', "
                             f"but some of its elements are not in the list of allowed values '{self.allowed_values}'.",
                         )
+
+        if is_set_and_present(self.values_editable_by) and self.values_editable_by not in {
+            "org_actors",
+            "org_and_repo_actors",
+        }:
+            context.add_failure(
+                FailureType.ERROR,
+                f"{self.get_model_header(parent_object)} has 'values_editable_by' of value "
+                f"'{self.values_editable_by}', "
+                f"while only values ('org_actors' | 'org_and_repo_actors' | null) are allowed.",
+            )
 
     def include_field_for_diff_computation(self, field: dataclasses.Field) -> bool:
         if self.required is not True and field.name in ["default_value"]:

--- a/otterdog/models/custom_property.py
+++ b/otterdog/models/custom_property.py
@@ -43,6 +43,7 @@ class CustomProperty(ModelObject):
     default_value: str | list[str] | None
     description: str | None
     allowed_values: list[str] | None
+    values_editable_by: str | None
 
     @property
     def model_object_name(self) -> str:
@@ -129,6 +130,17 @@ class CustomProperty(ModelObject):
                             f"'{self.default_value}', "
                             f"but some of its elements are not in the list of allowed values '{self.allowed_values}'.",
                         )
+
+        if is_set_and_present(self.values_editable_by) and self.values_editable_by not in {
+            "org_actors",
+            "org_and_repo_actors",
+        }:
+            context.add_failure(
+                FailureType.ERROR,
+                f"{self.get_model_header(parent_object)} has 'values_editable_by' of value "
+                f"'{self.values_editable_by}', "
+                f"while only values ('org_actors' | 'org_and_repo_actors' | null) are allowed.",
+            )
 
     def include_field_for_diff_computation(self, field: dataclasses.Field) -> bool:
         if self.required is not True and field.name in ["default_value"]:

--- a/otterdog/resources/schemas/custom-property.json
+++ b/otterdog/resources/schemas/custom-property.json
@@ -11,6 +11,12 @@
     "allowed_values": {
       "type": "array",
       "items": { "type": "string" }
+    },
+    "values_editable_by": {
+      "anyOf": [
+        { "type": "string", "enum": ["org_actors", "org_and_repo_actors"] },
+        { "type": "null" }
+      ]
     }
   },
 

--- a/otterdog/webapp/templates/home/organization.html
+++ b/otterdog/webapp/templates/home/organization.html
@@ -457,6 +457,7 @@
                             <th>Required</th>
                             <th>Default Value</th>
                             <th>Allowed Values</th>
+                            <th>Values Editable By</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -474,6 +475,11 @@
                             <td>
                               {% if custom_property.allowed_values %}
                               {{ custom_property.allowed_values|pprint }}
+                              {% endif %}
+                            </td>
+                            <td>
+                              {% if custom_property.values_editable_by %}
+                              {{ custom_property.values_editable_by }}
                               {% endif %}
                             </td>
                           </tr>

--- a/tests/models/test_custom_property.py
+++ b/tests/models/test_custom_property.py
@@ -34,6 +34,7 @@ class CustomPropertyTest(ModelTest):
             "default_value": "Python",
             "description": "Primary language",
             "allowed_values": ["Python", "Java"],
+            "values_editable_by": "org_and_repo_actors",
         }
 
     @property
@@ -45,6 +46,7 @@ class CustomPropertyTest(ModelTest):
             "default_value": "Python",
             "description": "Primary language",
             "allowed_values": ["Python", "Java"],
+            "values_editable_by": "org_and_repo_actors",
         }
 
     def test_load_from_model(self):
@@ -57,6 +59,7 @@ class CustomPropertyTest(ModelTest):
         assert custom_property.default_value == "Python"
         assert custom_property.description == "Primary language"
         assert custom_property.allowed_values == ["Python", "Java"]
+        assert custom_property.values_editable_by == "org_and_repo_actors"
 
     def test_load_from_provider(self):
         """Loads a custom property from provider data."""
@@ -68,6 +71,7 @@ class CustomPropertyTest(ModelTest):
         assert custom_property.default_value == "Python"
         assert custom_property.description == "Primary language"
         assert custom_property.allowed_values == ["Python", "Java"]
+        assert custom_property.values_editable_by == "org_and_repo_actors"
 
     async def test_to_provider_excludes_name(self):
         """Converts to provider data without including the name key."""

--- a/tests/providers/github/integration/test_org_custom_properties.py
+++ b/tests/providers/github/integration/test_org_custom_properties.py
@@ -45,6 +45,7 @@ async def test_create(github: GitHubProviderTestKit):
             "default_value": "Python",
             "description": "Primary language",
             "allowed_values": ["Python", "Java"],
+            "values_editable_by": None,
         },
         response_json={},
     )
@@ -59,6 +60,7 @@ async def test_create(github: GitHubProviderTestKit):
             default_value="Python",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
     )
 
@@ -76,6 +78,7 @@ async def test_read(github: GitHubProviderTestKit):
                 "default_value": "Python",
                 "description": "Primary language",
                 "allowed_values": ["Python", "Java"],
+                "values_editable_by": None,
             },
             {
                 "property_name": "cost_center",
@@ -83,6 +86,7 @@ async def test_read(github: GitHubProviderTestKit):
                 "required": False,
                 "default_value": "",
                 "description": None,
+                "values_editable_by": None,
             },
         ],
     )
@@ -98,6 +102,7 @@ async def test_read(github: GitHubProviderTestKit):
             default_value="Python",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
         CustomProperty(
             name="cost_center",
@@ -106,6 +111,7 @@ async def test_read(github: GitHubProviderTestKit):
             default_value="",
             description=None,
             allowed_values=[],
+            values_editable_by=None,
         ),
     ]
 
@@ -121,6 +127,7 @@ async def test_update(github: GitHubProviderTestKit):
             "default_value": "Java",
             "description": "Primary language",
             "allowed_values": ["Python", "Java"],
+            "values_editable_by": None,
         },
         response_json={},
     )
@@ -134,6 +141,7 @@ async def test_update(github: GitHubProviderTestKit):
             default_value="Python",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
         new=CustomProperty(
             name="language",
@@ -142,6 +150,7 @@ async def test_update(github: GitHubProviderTestKit):
             default_value="Java",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
     )
 
@@ -163,6 +172,7 @@ async def test_delete(github: GitHubProviderTestKit):
             default_value="Python",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
         new=None,
     )

--- a/tests/providers/github/integration/test_org_custom_properties.py
+++ b/tests/providers/github/integration/test_org_custom_properties.py
@@ -45,6 +45,7 @@ async def test_create(github: GitHubProviderTestKit):
             "default_value": "Python",
             "description": "Primary language",
             "allowed_values": ["Python", "Java"],
+            "values_editable_by": None,
         },
         response_json={},
     )
@@ -59,6 +60,7 @@ async def test_create(github: GitHubProviderTestKit):
             default_value="Python",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
     )
 
@@ -132,6 +134,7 @@ async def test_read(github: GitHubProviderTestKit):
                 "default_value": "Python",
                 "description": "Primary language",
                 "allowed_values": ["Python", "Java"],
+                "values_editable_by": None,
             },
             {
                 "property_name": "cost_center",
@@ -139,6 +142,7 @@ async def test_read(github: GitHubProviderTestKit):
                 "required": False,
                 "default_value": "",
                 "description": None,
+                "values_editable_by": None,
             },
         ],
     )
@@ -154,6 +158,7 @@ async def test_read(github: GitHubProviderTestKit):
             default_value="Python",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
         CustomProperty(
             name="cost_center",
@@ -162,6 +167,7 @@ async def test_read(github: GitHubProviderTestKit):
             default_value="",
             description=None,
             allowed_values=[],
+            values_editable_by=None,
         ),
     ]
 
@@ -177,6 +183,7 @@ async def test_update(github: GitHubProviderTestKit):
             "default_value": "Java",
             "description": "Primary language",
             "allowed_values": ["Python", "Java"],
+            "values_editable_by": None,
         },
         response_json={},
     )
@@ -190,6 +197,7 @@ async def test_update(github: GitHubProviderTestKit):
             default_value="Python",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
         new=CustomProperty(
             name="language",
@@ -198,6 +206,7 @@ async def test_update(github: GitHubProviderTestKit):
             default_value="Java",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
     )
 
@@ -219,6 +228,7 @@ async def test_delete(github: GitHubProviderTestKit):
             default_value="Python",
             description="Primary language",
             allowed_values=["Python", "Java"],
+            values_editable_by=None,
         ),
         new=None,
     )

--- a/tests/providers/github/integration/test_org_custom_properties.py
+++ b/tests/providers/github/integration/test_org_custom_properties.py
@@ -75,6 +75,7 @@ async def test_create_string_type(github: GitHubProviderTestKit):
             "required": False,
             "default_value": "",
             "description": None,
+            "values_editable_by": None,
         },
         response_json={},
     )
@@ -89,6 +90,7 @@ async def test_create_string_type(github: GitHubProviderTestKit):
             default_value="",
             description=None,
             allowed_values=[],
+            values_editable_by=None,
         ),
     )
 
@@ -103,6 +105,7 @@ async def test_create_string_type_with_non_empty_allowed_values(github: GitHubPr
             "required": False,
             "default_value": "",
             "description": None,
+            "values_editable_by": None,
         },
         response_json={},
     )
@@ -117,6 +120,7 @@ async def test_create_string_type_with_non_empty_allowed_values(github: GitHubPr
             default_value="",
             description=None,
             allowed_values=["some_value"],
+            values_editable_by=None,
         ),
     )
 


### PR DESCRIPTION
## Summary

Adds the `values_editable_by` field to organization custom properties. This controls which actors can update a property's value on individual repositories once it has been defined at the org level.

## Allowed values

- `org_actors` — only organization actors can update the value
- `org_and_repo_actors` — both organization and repository actors can update
- `null` (default) — not settable at the repository level

## Example

```jsonnet
settings+: {
  custom_properties+: [
    orgs.newCustomProperty('cost_center') {
      value_type: 'string',
      required: true,
      default_value: 'platform',
      values_editable_by: 'org_and_repo_actors',
    },
  ],
},
```

## Changes

- `otterdog/models/custom_property.py` — new `values_editable_by: str | None` field with enum validation.
- `examples/template/otterdog-defaults.libsonnet` — default `values_editable_by: null` on `newCustomProperty`.
- `otterdog/resources/schemas/custom-property.json` — `anyOf` enum-or-null schema.
- `tests/models/test_custom_property.py` + `tests/providers/github/integration/test_org_custom_properties.py` — updated to cover the new field.

## Testing

- `poetry run pytest tests/` → 243 passed, 2 skipped, 0 failures
- `poetry run mypy otterdog` → clean
- `poetry run ruff check` / `ruff format --check` → clean