### PR TITLE
fix ruleset default value when UNSET for mapped fields

### DIFF
--- a/otterdog/models/__init__.py
+++ b/otterdog/models/__init__.py
@@ -190,8 +190,26 @@ class LivePatchHandler(Protocol):
     def __call__(self, patch: LivePatch) -> None: ...
 
 
+class _DefaultValuesMixin:
+    """
+    Mixin that replaces UNSET field values with their Python dataclass defaults in __post_init__.
+    """
+
+    def __post_init__(self):
+        """
+        Assigns to all field which are UNSET their default value, if one is available.
+        """
+        for field in self.all_fields():  # type: ignore[attr-defined]
+            value = self.__getattribute__(field.name)
+            if is_unset(value):
+                if field.default is not dataclasses.MISSING:
+                    self.__setattr__(field.name, field.default)
+                elif field.default_factory is not dataclasses.MISSING:
+                    self.__setattr__(field.name, field.default_factory())
+
+
 @dataclasses.dataclass
-class EmbeddedModelObject(ABC):
+class EmbeddedModelObject(_DefaultValuesMixin, ABC):
     """
     The abstract base class for embedded model objects.
     """
@@ -337,22 +355,10 @@ class EmbeddedModelObject(ABC):
 
 
 @dataclasses.dataclass
-class ModelObject(ABC):
+class ModelObject(_DefaultValuesMixin, ABC):
     """
     The abstract base class for any model object.
     """
-
-    def __post_init__(self):
-        """
-        Assigns to all field which are UNSET their default value, if one is available.
-        """
-        for field in self.all_fields():
-            value = self.__getattribute__(field.name)
-            if is_unset(value):
-                if field.default is not dataclasses.MISSING:
-                    self.__setattr__(field.name, field.default)
-                elif field.default_factory is not dataclasses.MISSING:
-                    self.__setattr__(field.name, field.default_factory())
 
     @property
     @abstractmethod

--- a/otterdog/models/ruleset.py
+++ b/otterdog/models/ruleset.py
@@ -49,10 +49,10 @@ _logger = get_logger(__name__)
 @dataclasses.dataclass
 class PullRequestSettings(EmbeddedModelObject):
     required_approving_review_count: int
-    dismisses_stale_reviews: bool
-    requires_code_owner_review: bool
-    requires_last_push_approval: bool
-    requires_review_thread_resolution: bool
+    dismisses_stale_reviews: bool = dataclasses.field(default=False)
+    requires_code_owner_review: bool = dataclasses.field(default=False)
+    requires_last_push_approval: bool = dataclasses.field(default=False)
+    requires_review_thread_resolution: bool = dataclasses.field(default=False)
 
     def validate(self, context: ValidationContext, parent_object: Any) -> None:
         for key in self.keys(False):


### PR DESCRIPTION
Current error on the eclipse score project

│ │ current_org_number = 1                                                                        │ │
│ │                exc = BendingException("Error for key require_last_push_approval:              │ │
│ │                      'requires_last_push_approval'")                                          │ │
│ │          exit_code = 0                                                                        │ │
│ │          operation = <otterdog.operations.apply.ApplyOperation object at 0x7c965a23c830>      │ │
│ │         org_config = OrganizationConfig('automotive.score', 'eclipse-score', '.eclipsefdn',   │ │
│ │                      {})                                                                      │ │
│ │       organization = 'eclipse-score'                                                          │ │
│ │      organizations = ('eclipse-score',)                                                       │ │
│ │            printer = <otterdog.utils.IndentingPrinter object at 0x7c965a23dfd0>               │ │
│ │     total_num_orgs = 1                     


ref issue: 
* https://github.com/eclipse-csi/otterdog/issues/674
* https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/work_items/7620
