### PR TITLE
fix: strip OTTERDOG_CONFIG_TOKEN and fix log info for config_file_path

### DIFF
--- a/otterdog/webapp/utils.py
+++ b/otterdog/webapp/utils.py
@@ -195,7 +195,7 @@ def _get_otterdog_config_url() -> str:
     config_file_repo = current_app.config["OTTERDOG_CONFIG_REPO"]
     config_file_path = current_app.config["OTTERDOG_CONFIG_PATH"]
 
-    return f"'https://github.com/{config_file_owner}/{config_file_repo}/{config_file_path}'"
+    return f"'https://github.com/{config_file_owner}/{config_file_repo}/blob/main/{config_file_path}'"
 
 
 async def _load_otterdog_config(ref: str | None = None) -> OtterdogConfig:
@@ -206,10 +206,10 @@ async def _load_otterdog_config(ref: str | None = None) -> OtterdogConfig:
 
     logger.info(
         f"loading otterdog config from url "
-        f"'https://github.com/{config_file_owner}/{config_file_repo}/{config_file_path}'"
+        f"'https://github.com/{config_file_owner}/{config_file_repo}/blob/main/{config_file_path}'"
     )
 
-    async with RestApi(token_auth(current_app.config["OTTERDOG_CONFIG_TOKEN"]), get_github_cache()) as rest_api:
+    async with RestApi(token_auth(current_app.config["OTTERDOG_CONFIG_TOKEN"].strip()), get_github_cache()) as rest_api:
         content = await rest_api.content.get_content(config_file_owner, config_file_repo, config_file_path, ref)
         import aiofiles
 
@@ -233,12 +233,12 @@ async def _load_global_policies(ref: str | None = None) -> list[Policy]:
 
     logger.info(
         f"loading global policies from url "
-        f"'https://github.com/{config_file_owner}/{config_file_repo}/{config_file_path}'"
+        f"'https://github.com/{config_file_owner}/{config_file_repo}/blob/main/{config_file_path}'"
     )
 
     policies = {}
 
-    async with RestApi(token_auth(current_app.config["OTTERDOG_CONFIG_TOKEN"]), get_github_cache()) as rest_api:
+    async with RestApi(token_auth(current_app.config["OTTERDOG_CONFIG_TOKEN"].strip()), get_github_cache()) as rest_api:
         try:
             entries = await rest_api.content.get_content_object(
                 config_file_owner, config_file_repo, config_file_path, ref
@@ -278,12 +278,12 @@ async def _load_global_blueprints(ref: str | None = None) -> list[Blueprint]:
 
     logger.info(
         f"loading global blueprints from url "
-        f"'https://github.com/{config_file_owner}/{config_file_repo}/{config_file_path}'"
+        f"'https://github.com/{config_file_owner}/{config_file_repo}/blob/main/{config_file_path}'"
     )
 
     blueprints = {}
 
-    async with RestApi(token_auth(current_app.config["OTTERDOG_CONFIG_TOKEN"]), get_github_cache()) as rest_api:
+    async with RestApi(token_auth(current_app.config["OTTERDOG_CONFIG_TOKEN"].strip()), get_github_cache()) as rest_api:
         try:
             entries = await rest_api.content.get_content_object(
                 config_file_owner, config_file_repo, config_file_path, ref


### PR DESCRIPTION
When the GitHub token contains a trailing newline or a control character, Otterdog fails while performing GitHub REST API requests.

The GitHub token was not stripped before being used in the request headers.

```shell
   [2026-06-29 15:01:40.449  ] [8] [INFO] loading otterdog config from url 'https://github.com/otterdog-heurtematte/otterdog-configs/otterdog.json'                           │
│ otterdog [2026-06-29 15:01:40.452  ] [8] [DEBUG] retrieving content 'otterdog.json' from repo 'otterdog-heurtematte/otterdog-configs'                                               │
│ otterdog Traceback (most recent call last):                                                                                                                                         │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/quart/app.py", line 1500, in full_dispatch_request                                                                         │
│ otterdog     result = await self.dispatch_request(request_context)                                                                                                                  │
│ otterdog              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                  │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/quart/app.py", line 1597, in dispatch_request                                                                              │
│ otterdog     return await self.ensure_async(handler)(**request_.view_args)  # type: ignore[return-value]                                                                            │
│ otterdog            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                          │
│ otterdog   File "/app/otterdog/webapp/internal/routes.py", line 37, in init                                                                                                         │
│ otterdog     config = await refresh_otterdog_config()                                                                                                                               │
│ otterdog              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                               │
│ otterdog   File "/app/otterdog/webapp/utils.py", line 175, in refresh_otterdog_config                                                                                               │
│ otterdog     config = await _load_otterdog_config(sha)                                                                                                                              │
│ otterdog              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                              │
│ otterdog   File "/app/otterdog/webapp/utils.py", line 213, in _load_otterdog_config                                                                                                 │
│ otterdog     content = await rest_api.content.get_content(config_file_owner, config_file_repo, config_file_path, ref)                                                               │
│ otterdog               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                               │
│ otterdog   File "/app/otterdog/providers/github/rest/content_client.py", line 47, in get_content                                                                                    │
│ otterdog     json_response = await self.get_content_object(org_id, repo_name, path, ref)                                                                                            │
│ otterdog                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                            │
│ otterdog   File "/app/otterdog/providers/github/rest/content_client.py", line 40, in get_content_object                                                                             │
│ otterdog     return await self.requester.request_json(                                                                                                                              │
│ otterdog            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                              │
│ otterdog   File "/app/otterdog/providers/github/rest/requester.py", line 128, in request_json                                                                                       │
│ otterdog     status, body = await self.request_raw(method, url_path, input_data, params)         
│ otterdog   File "/app/otterdog/providers/github/rest/requester.py", line 128, in request_json                                                                                       │
│ otterdog     status, body = await self.request_raw(method, url_path, input_data, params)                                                                                            │
│ otterdog                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                            │
│ otterdog   File "/app/otterdog/providers/github/rest/requester.py", line 142, in request_raw                                                                                        │
│ otterdog     status, body, _, _ = await self._request_raw_with_next_link(method, url_path, data, params)                                                                            │
│ otterdog                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                            │
│ otterdog   File "/app/otterdog/providers/github/rest/requester.py", line 171, in _request_raw_with_next_link                                                                        │
│ otterdog     async with self._client.request(                                                                                                                                       │
│ otterdog                ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                       │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/aiohttp_retry/client.py", line 158, in __aenter__                                                                          │
│ otterdog     return await self._do_request()                                                                                                                                        │
│ otterdog            ^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                        │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/aiohttp_retry/client.py", line 119, in _do_request                                                                         │
│ otterdog     response: ClientResponse = await self._request_func(                                                                                                                   │
│ otterdog                                ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                   │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 856, in _request                                                                                  │
│ otterdog     resp = await handler(req)                                                                                                                                              │
│ otterdog            ^^^^^^^^^^^^^^^^^^                                                                                                                                              │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 832, in _connect_and_send_request                                                                 │
│ otterdog     resp = await req.send(conn)                                                                                                                                            │
│ otterdog            ^^^^^^^^^^^^^^^^^^^^                                                                                                                                            │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 1488, in send                                                                              │
│ otterdog     await writer.write_headers(status_line, self.headers)                                                                                                                  │
│ otterdog   File "/app/.venv/lib/python3.12/site-packages/aiohttp/http_writer.py", line 214, in write_headers                                                                        │
│ otterdog     buf = _serialize_headers(status_line, headers)                                                                                                                         │
│ otterdog           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                         │
│ otterdog   File "aiohttp/_http_writer.pyx", line 150, in aiohttp._http_writer._serialize_headers                                                                                    │
│ otterdog   File "aiohttp/_http_writer.pyx", line 117, in aiohttp._http_writer._write_str_raise_on_nlcr                                                                              │
│ otterdog ValueError: Forbidden control character detected in headers. Potential header injection attack.       

```