### PR TITLE
Add environment variables and secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [Unreleased]
+
+### Added
+
+ - Add support for environment secrets and variables ([#537](https://github.com/eclipse-csi/otterdog/issues/537))
+ - Add support for `prevent_self_review` on environments ([#680](https://github.com/eclipse-csi/otterdog/issues/680))
+
 ## [1.3.4] - 29/06/2026
 
 ### Fixed

--- a/docs/reference/organization/repository/environment-secret.md
+++ b/docs/reference/organization/repository/environment-secret.md
@@ -1,0 +1,65 @@
+Definition of a `Secret` on environment level, the following properties are supported:
+
+| Key                     | Value          | Description                                    | Note |
+|-------------------------|----------------|------------------------------------------------|------|
+| _name_                  | string         | The name of the secret                         |      |
+| _value_                 | string         | The secret value                               |      |
+
+The secret value can be resolved via a credential provider. The supported format is `<credential_provider>:<provider specific data>`.
+
+- Bitwarden: `bitwarden:<bitwarden item id>@<custom_field_key>`
+
+    ``` json
+    "secret": "bitwarden:118276ad-158c-4720-b68d-af8c00fe3481@secret"
+    ```
+
+- Pass: `pass:<path/to/secret>`
+
+    ``` json
+    "secret": "pass:path/to/repo/secret"
+    ```
+
+!!! note
+
+    After executing an `import` operation, the secret will be set to `********` as GitHub will not disclose the
+    secret value anymore via its API. You will need to update the configuration with the real secret value, either
+    by entering the secret value (not advised), or referencing it via a credential provider.
+
+    Secrets which have a redacted value defined will be skipped during processing.
+
+## Jsonnet Function
+
+``` jsonnet
+orgs.newEnvironmentSecret('<name>') {
+  <key>: <value>
+}
+```
+
+## Validation rules
+
+- redacted secret values (`********`) trigger a validation info and will skip the secret during processing
+
+## Example usage
+
+=== "jsonnet"
+    ``` jsonnet
+    orgs.newOrg('OtterdogTest') {
+      ...
+      _repositories+:: [
+        ...
+        orgs.newRepo('test-repo') {
+          ...
+          environments: [
+            orgs.newEnvironment('linux') {
+              ...
+              secrets+: [
+                orgs.newEnvironmentSecret('TEST_SECRET') {
+                  value: "pass:path/to/secret",
+                },
+              ],
+            },
+          ]
+        }
+      ]
+    }
+    ```

--- a/docs/reference/organization/repository/environment-variable.md
+++ b/docs/reference/organization/repository/environment-variable.md
@@ -1,0 +1,43 @@
+Definition of a `Variable` on environment level, the following properties are supported:
+
+| Key                     | Value          | Description              | Note |
+|-------------------------|----------------|--------------------------|------|
+| _name_                  | string         | The name of the variable |      |
+| _value_                 | string         | The variable value       |      |
+
+## Jsonnet Function
+
+``` jsonnet
+orgs.newEnvironmentVariable('<name>') {
+  <key>: <value>
+}
+```
+
+## Validation rules
+
+- None
+
+## Example usage
+
+=== "jsonnet"
+    ``` jsonnet
+    orgs.newOrg('OtterdogTest') {
+      ...
+      _repositories+:: [
+        ...
+        orgs.newRepo('test-repo') {
+          ...
+          environments: [
+            orgs.newEnvironment('linux') {
+              ...
+              variables+: [
+                orgs.newEnvironmentVariable('TEST_VARIABLE') {
+                  value: "TESTVALUE",
+                },
+              ],
+            },
+          ]
+        }
+      ]
+    }
+    ```

--- a/docs/reference/organization/repository/environment.md
+++ b/docs/reference/organization/repository/environment.md
@@ -5,8 +5,11 @@ Definition of an `Environment` on repository level, the following properties are
 | _name_                     | string                                  | The name of the environment                                                           |                                                                    |
 | _wait_timer_               | int                                     | The amount of time to wait before allowing deployments to proceed                     |                                                                    |
 | _reviewers_                | list\[[Actor](actor.md)\]               | Users or Teams that may approve workflow runs that access this environment            |                                                                    |
+| _prevent_self_review_      | bool                                    | Whether a user who triggered a workflow run is prevented from approving it            |                                                                    |
 | _deployment_branch_policy_ | string                                  | Limit which branches can deploy to this environment based on rules or naming patterns | `all`, `protected` or `selected`                                   |
 | _branch_policies_          | list\[[BranchOrTag](branch-or-tag.md)\] | List of branch or tag patterns which can deploy to this environment                   | only applicable if `deployment_branch_policy` is set to `selected` |
+| _secrets_                  | list\[[EnvironmentSecret](environment-secret.md)\]     | secrets defined for this environment, see section below for details   |                                                                    |
+| _variables_                | list\[[EnvironmentVariable](environment-variable.md)\] | variables defined for this environment, see section below for details |                                                                   |
 
 ## Jsonnet Function
 
@@ -37,7 +40,18 @@ orgs.newEnvironment('<name>') {
                 "@OtterdogTest/eclipsefdn-security",
                 "@netomi"
               ],
+              prevent_self_review: true,
               wait_timer: 30,
+              secrets+: [
+                orgs.newEnvironmentSecret('TEST_SECRET') {
+                  value: "pass:path/to/secret",
+                },
+              ],
+              variables+: [
+                orgs.newEnvironmentVariable('TEST_VARIABLE') {
+                  value: "TESTVALUE",
+                },
+              ],
             },
           ]
         }

--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -274,10 +274,19 @@ local newEnvironment(name) = {
   name: name,
   wait_timer: 0,
   reviewers: [],
+  prevent_self_review: false,
   # Can be one of: all, protected_branches, branch_policies
   deployment_branch_policy: "all",
   branch_policies: [],
+  secrets: [],
+  variables: [],
 };
+
+# Function to create a new environment secret with default settings.
+local newEnvironmentSecret(name) = newRepoSecret(name);
+
+# Function to create a new environment variable with default settings.
+local newEnvironmentVariable(name) = newRepoVariable(name);
 
 # Function to create a new custom property with default settings.
 local newCustomProperty(name) = {
@@ -440,6 +449,8 @@ local newOrg(name, id=name) = {
   newBranchProtectionRule:: newBranchProtectionRule,
   newRepoRuleset:: newRepoRuleset,
   newEnvironment:: newEnvironment,
+  newEnvironmentSecret:: newEnvironmentSecret,
+  newEnvironmentVariable:: newEnvironmentVariable,
   newPullRequest:: newPullRequest,
   newStatusChecks:: newStatusChecks,
   newMergeQueue:: newMergeQueue,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,8 @@ nav:
           - Repository Secret: reference/organization/repository/secret.md
           - Repository Variable: reference/organization/repository/variable.md
           - Environment: reference/organization/repository/environment.md
+          - Environment Secret: reference/organization/repository/environment-secret.md
+          - Environment Variable: reference/organization/repository/environment-variable.md
           - Branch Protection Rule: reference/organization/repository/branch-protection-rule.md
           - Repository Ruleset: reference/organization/repository/ruleset.md
         - Referenced Types:

--- a/otterdog/jsonnet.py
+++ b/otterdog/jsonnet.py
@@ -42,6 +42,8 @@ class JsonnetConfig:
     create_branch_protection_rule = "newBranchProtectionRule"
     create_repo_ruleset = "newRepoRuleset"
     create_environment = "newEnvironment"
+    create_environment_secret = "newEnvironmentSecret"
+    create_environment_variable = "newEnvironmentVariable"
     create_pull_request = "newPullRequest"
     create_status_checks = "newStatusChecks"
     create_merge_queue = "newMergeQueue"
@@ -81,6 +83,8 @@ class JsonnetConfig:
         self._default_branch_protection_rule_config: dict[str, Any] | None = None
         self._default_repo_ruleset_config: dict[str, Any] | None = None
         self._default_environment_config: dict[str, Any] | None = None
+        self._default_environment_secret_config: dict[str, Any] | None = None
+        self._default_environment_variable_config: dict[str, Any] | None = None
         self._default_pull_request_config: dict[str, Any] | None = None
         self._default_status_checks_config: dict[str, Any] | None = None
         self._default_merge_queue_config: dict[str, Any] | None = None
@@ -259,6 +263,28 @@ class JsonnetConfig:
             return jsonnet_evaluate_snippet(environment_snippet)
         except RuntimeError:
             _logger.debug("no default environment config found, environments will be skipped")
+            return None
+
+    @cached_property
+    def default_environment_secret_config(self):
+        try:
+            # load the default environment secret config
+            environment_secret_snippet = f"(import '{self.template_file}').{self.create_environment_secret}('default')"
+            return jsonnet_evaluate_snippet(environment_secret_snippet)
+        except RuntimeError:
+            _logger.debug("no default environment secret config found, secrets will be skipped")
+            return None
+
+    @cached_property
+    def default_environment_variable_config(self):
+        try:
+            # load the default environment variable config
+            environment_variable_snippet = (
+                f"(import '{self.template_file}').{self.create_environment_variable}('default')"
+            )
+            return jsonnet_evaluate_snippet(environment_variable_snippet)
+        except RuntimeError:
+            _logger.debug("no default environment variable config found, variables will be skipped")
             return None
 
     @cached_property

--- a/otterdog/models/environment.py
+++ b/otterdog/models/environment.py
@@ -16,13 +16,20 @@ from jsonbender import F, Filter, Forall, If, K, OptionalS, S  # type: ignore
 from otterdog.models import (
     FailureType,
     LivePatch,
+    LivePatchContext,
+    LivePatchHandler,
     LivePatchType,
     ModelObject,
     ValidationContext,
 )
-from otterdog.utils import expect_type, is_set_and_valid, is_unset, unwrap
+from otterdog.utils import Change, expect_type, is_set_and_valid, is_unset, unwrap
+
+from .environment_secret import EnvironmentSecret
+from .environment_variable import EnvironmentVariable
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
     from otterdog.jsonnet import JsonnetConfig
     from otterdog.providers.github import GitHubProvider
 
@@ -35,15 +42,62 @@ class Environment(ModelObject):
 
     id: int = dataclasses.field(metadata={"external_only": True})
     node_id: str = dataclasses.field(metadata={"external_only": True})
+    # the name of the repository this environment belongs to, only used at runtime to
+    # be able to address the correct REST endpoints for nested secrets / variables,
+    # never part of the jsonnet configuration or diff computation.
+    repo_name: str = dataclasses.field(metadata={"external_only": True})
     name: str = dataclasses.field(metadata={"key": True})
     wait_timer: int
     reviewers: list[str]
+    prevent_self_review: bool
     deployment_branch_policy: str
     branch_policies: list[str]
+
+    # nested model fields
+    secrets: list[EnvironmentSecret] = dataclasses.field(metadata={"nested_model": True}, default_factory=list)
+    variables: list[EnvironmentVariable] = dataclasses.field(metadata={"nested_model": True}, default_factory=list)
 
     @property
     def model_object_name(self) -> str:
         return "environment"
+
+    def add_secret(self, secret: EnvironmentSecret) -> None:
+        self.secrets.append(secret)
+
+    def get_secret(self, name: str) -> EnvironmentSecret | None:
+        return next(filter(lambda x: x.name == name, self.secrets), None)
+
+    def set_secrets(self, secrets: list[EnvironmentSecret]) -> None:
+        self.secrets = secrets
+
+    def add_variable(self, variable: EnvironmentVariable) -> None:
+        self.variables.append(variable)
+
+    def get_variable(self, name: str) -> EnvironmentVariable | None:
+        return next(filter(lambda x: x.name == name, self.variables), None)
+
+    def set_variables(self, variables: list[EnvironmentVariable]) -> None:
+        self.variables = variables
+
+    def get_model_objects(self) -> Iterator[tuple[ModelObject, ModelObject]]:
+        for secret in self.secrets:
+            yield secret, self
+            yield from secret.get_model_objects()
+
+        for variable in self.variables:
+            yield variable, self
+            yield from variable.get_model_objects()
+
+    def resolve_secrets(self, secret_resolver: Callable[[str], str]) -> None:
+        for secret in self.secrets:
+            secret.resolve_secrets(secret_resolver)
+
+    def copy_secrets(self, other_object: ModelObject) -> None:
+        other_environment = expect_type(other_object, Environment)
+        for secret in self.secrets:
+            other_secret = other_environment.get_secret(secret.name)
+            if other_secret is not None:
+                secret.copy_secrets(other_secret)
 
     def validate(self, context: ValidationContext, parent_object: Any) -> None:
         if not is_unset(self.wait_timer) and not (0 <= self.wait_timer <= 43200):
@@ -141,6 +195,10 @@ class Environment(ModelObject):
                 >> OptionalS(0, default={})
                 >> OptionalS("reviewers", default=[])
                 >> Forall(lambda x: transform_reviewers(x)),
+                "prevent_self_review": OptionalS("protection_rules", default=[])
+                >> Filter(lambda obj: obj.get("type") == "required_reviewers")
+                >> OptionalS(0, default={})
+                >> OptionalS("prevent_self_review", default=False),
                 "deployment_branch_policy": OptionalS("deployment_branch_policy") >> F(transform_policy),
                 "branch_policies": OptionalS("branch_policies", default=[]) >> Forall(transform_branch_policy),
             }
@@ -191,6 +249,70 @@ class Environment(ModelObject):
 
     def get_jsonnet_template_function(self, jsonnet_config: JsonnetConfig, extend: bool) -> str | None:
         return f"orgs.{jsonnet_config.create_environment}"
+
+    @classmethod
+    def get_mapping_from_model(cls) -> dict[str, Any]:
+        mapping = super().get_mapping_from_model()
+
+        mapping.update(
+            {
+                "secrets": OptionalS("secrets", default=[]) >> Forall(lambda x: EnvironmentSecret.from_model_data(x)),
+                "variables": OptionalS("variables", default=[])
+                >> Forall(lambda x: EnvironmentVariable.from_model_data(x)),
+            }
+        )
+
+        return mapping
+
+    @classmethod
+    def generate_live_patch(
+        cls,
+        expected_object: Environment | None,
+        current_object: Environment | None,
+        parent_object: ModelObject | None,
+        context: LivePatchContext,
+        handler: LivePatchHandler,
+    ) -> None:
+        if expected_object is None:
+            current_object = unwrap(current_object)
+            handler(LivePatch.of_deletion(current_object, parent_object, current_object.apply_live_patch))
+            # deleting the environment implicitly removes its secrets / variables as well,
+            # so there is no need to generate explicit live patches for them.
+            return
+
+        expected_object = unwrap(expected_object)
+
+        if current_object is None:
+            handler(LivePatch.of_addition(expected_object, parent_object, expected_object.apply_live_patch))
+        else:
+            modified_env: dict[str, Change[Any]] = expected_object.get_difference_from(current_object)
+            if len(modified_env) > 0:
+                handler(
+                    LivePatch.of_changes(
+                        expected_object,
+                        current_object,
+                        modified_env,
+                        parent_object,
+                        False,
+                        expected_object.apply_live_patch,
+                    )
+                )
+
+        EnvironmentSecret.generate_live_patch_of_list(
+            expected_object.secrets,
+            current_object.secrets if current_object is not None else [],
+            expected_object,
+            context,
+            handler,
+        )
+
+        EnvironmentVariable.generate_live_patch_of_list(
+            expected_object.variables,
+            current_object.variables if current_object is not None else [],
+            expected_object,
+            context,
+            handler,
+        )
 
     @classmethod
     async def apply_live_patch(cls, patch: LivePatch[Environment], org_id: str, provider: GitHubProvider) -> None:

--- a/otterdog/models/environment_secret.py
+++ b/otterdog/models/environment_secret.py
@@ -1,0 +1,71 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from otterdog.models import LivePatch, LivePatchType
+from otterdog.models.secret import Secret
+from otterdog.utils import expect_type, unwrap
+
+if TYPE_CHECKING:
+    from otterdog.jsonnet import JsonnetConfig
+    from otterdog.providers.github import GitHubProvider
+
+
+@dataclasses.dataclass
+class EnvironmentSecret(Secret):
+    """
+    Represents a Secret defined on environment level.
+    """
+
+    @property
+    def model_object_name(self) -> str:
+        return "env_secret"
+
+    def get_jsonnet_template_function(self, jsonnet_config: JsonnetConfig, extend: bool) -> str | None:
+        return f"orgs.{jsonnet_config.create_environment_secret}"
+
+    @classmethod
+    async def apply_live_patch(
+        cls,
+        patch: LivePatch[EnvironmentSecret],
+        org_id: str,
+        provider: GitHubProvider,
+    ) -> None:
+        from .environment import Environment
+
+        environment = expect_type(patch.parent_object, Environment)
+
+        match patch.patch_type:
+            case LivePatchType.ADD:
+                await provider.add_environment_secret(
+                    org_id,
+                    environment.repo_name,
+                    environment.name,
+                    await unwrap(patch.expected_object).to_provider_data(org_id, provider),
+                )
+
+            case LivePatchType.REMOVE:
+                await provider.delete_environment_secret(
+                    org_id,
+                    environment.repo_name,
+                    environment.name,
+                    unwrap(patch.current_object).name,
+                )
+
+            case LivePatchType.CHANGE:
+                await provider.update_environment_secret(
+                    org_id,
+                    environment.repo_name,
+                    environment.name,
+                    unwrap(patch.current_object).name,
+                    await unwrap(patch.expected_object).to_provider_data(org_id, provider),
+                )

--- a/otterdog/models/environment_variable.py
+++ b/otterdog/models/environment_variable.py
@@ -1,0 +1,71 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from otterdog.models import LivePatch, LivePatchType
+from otterdog.models.variable import Variable
+from otterdog.utils import expect_type, unwrap
+
+if TYPE_CHECKING:
+    from otterdog.jsonnet import JsonnetConfig
+    from otterdog.providers.github import GitHubProvider
+
+
+@dataclasses.dataclass
+class EnvironmentVariable(Variable):
+    """
+    Represents a Variable defined on environment level.
+    """
+
+    @property
+    def model_object_name(self) -> str:
+        return "env_variable"
+
+    def get_jsonnet_template_function(self, jsonnet_config: JsonnetConfig, extend: bool) -> str | None:
+        return f"orgs.{jsonnet_config.create_environment_variable}"
+
+    @classmethod
+    async def apply_live_patch(
+        cls,
+        patch: LivePatch[EnvironmentVariable],
+        org_id: str,
+        provider: GitHubProvider,
+    ) -> None:
+        from .environment import Environment
+
+        environment = expect_type(patch.parent_object, Environment)
+
+        match patch.patch_type:
+            case LivePatchType.ADD:
+                await provider.add_environment_variable(
+                    org_id,
+                    environment.repo_name,
+                    environment.name,
+                    await unwrap(patch.expected_object).to_provider_data(org_id, provider),
+                )
+
+            case LivePatchType.REMOVE:
+                await provider.delete_environment_variable(
+                    org_id,
+                    environment.repo_name,
+                    environment.name,
+                    unwrap(patch.current_object).name,
+                )
+
+            case LivePatchType.CHANGE:
+                await provider.update_environment_variable(
+                    org_id,
+                    environment.repo_name,
+                    environment.name,
+                    unwrap(patch.current_object).name,
+                    await unwrap(patch.expected_object).to_provider_data(org_id, provider),
+                )

--- a/otterdog/models/github_organization.py
+++ b/otterdog/models/github_organization.py
@@ -32,6 +32,8 @@ from otterdog.models import (
 from otterdog.models.branch_protection_rule import BranchProtectionRule
 from otterdog.models.custom_property import CustomProperty
 from otterdog.models.environment import Environment
+from otterdog.models.environment_secret import EnvironmentSecret
+from otterdog.models.environment_variable import EnvironmentVariable
 from otterdog.models.organization_role import OrganizationRole
 from otterdog.models.organization_ruleset import OrganizationRuleset
 from otterdog.models.organization_secret import OrganizationSecret
@@ -757,7 +759,26 @@ async def _process_single_repo(
         # get environments of the repo
         environments = await rest_api.repo.get_environments(github_id, repo_name)
         for github_environment in environments:
-            repo.add_environment(Environment.from_provider_data(github_id, github_environment))
+            env = Environment.from_provider_data(github_id, github_environment)
+            env.repo_name = repo_name
+
+            if jsonnet_config.default_environment_secret_config is not None:
+                # get secrets of the environment
+                env_secrets = await rest_api.repo.get_environment_secrets(github_id, repo_name, env.name)
+                for github_secret in env_secrets:
+                    env.add_secret(EnvironmentSecret.from_provider_data(github_id, github_secret))
+            else:
+                _logger.debug("not reading environment secrets, no default config available")
+
+            if jsonnet_config.default_environment_variable_config is not None:
+                # get variables of the environment
+                env_variables = await rest_api.repo.get_environment_variables(github_id, repo_name, env.name)
+                for github_variable in env_variables:
+                    env.add_variable(EnvironmentVariable.from_provider_data(github_id, github_variable))
+            else:
+                _logger.debug("not reading environment variables, no default config available")
+
+            repo.add_environment(env)
     else:
         _logger.debug("not reading environments, no default config available")
 

--- a/otterdog/models/repository.py
+++ b/otterdog/models/repository.py
@@ -208,6 +208,15 @@ class Repository(ModelObject):
     def model_object_name(self) -> str:
         return "repository"
 
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+        # stamp the repository name onto each environment so that nested environment
+        # secrets / variables can address the correct REST endpoints later on, see
+        # Environment.repo_name.
+        for env in self.environments:
+            env.repo_name = self.name
+
     def get_all_names(self) -> list[str]:
         return [self.name, *self.aliases]
 
@@ -255,6 +264,9 @@ class Repository(ModelObject):
 
     def add_environment(self, environment: Environment) -> None:
         self.environments.append(environment)
+
+    def get_environment(self, name: str) -> Environment | None:
+        return next(filter(lambda x: x.name == name, self.environments), None)
 
     def set_environments(self, environments: list[Environment]) -> None:
         self.environments = environments
@@ -1028,6 +1040,9 @@ class Repository(ModelObject):
         for secret in self.secrets:
             secret.resolve_secrets(secret_resolver)
 
+        for env in self.environments:
+            env.resolve_secrets(secret_resolver)
+
     def copy_secrets(self, other_object: ModelObject) -> None:
         for webhook in self.webhooks:
             other_repo = cast("Repository", other_object)
@@ -1040,6 +1055,12 @@ class Repository(ModelObject):
             other_secret = other_repo.get_secret(secret.name)
             if other_secret is not None:
                 secret.copy_secrets(other_secret)
+
+        for env in self.environments:
+            other_repo = cast("Repository", other_object)
+            other_env = other_repo.get_environment(env.name)
+            if other_env is not None:
+                env.copy_secrets(other_env)
 
     def get_jsonnet_template_function(self, jsonnet_config: JsonnetConfig, extend: bool) -> str | None:
         return f"orgs.{jsonnet_config.extend_repo}" if extend else f"orgs.{jsonnet_config.create_repo}"

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -422,6 +422,36 @@ class GitHubProvider:
     async def delete_repo_variable(self, org_id: str, repo_name: str, variable_name: str) -> None:
         await self.rest_api.repo.delete_variable(org_id, repo_name, variable_name)
 
+    async def get_environment_secrets(self, org_id: str, repo_name: str, env_name: str) -> list[dict[str, Any]]:
+        return await self.rest_api.repo.get_environment_secrets(org_id, repo_name, env_name)
+
+    async def update_environment_secret(
+        self, org_id: str, repo_name: str, env_name: str, secret_name: str, secret: dict[str, Any]
+    ) -> None:
+        if len(secret) > 0:
+            await self.rest_api.repo.update_environment_secret(org_id, repo_name, env_name, secret_name, secret)
+
+    async def add_environment_secret(self, org_id: str, repo_name: str, env_name: str, data: dict[str, str]) -> None:
+        await self.rest_api.repo.add_environment_secret(org_id, repo_name, env_name, data)
+
+    async def delete_environment_secret(self, org_id: str, repo_name: str, env_name: str, secret_name: str) -> None:
+        await self.rest_api.repo.delete_environment_secret(org_id, repo_name, env_name, secret_name)
+
+    async def get_environment_variables(self, org_id: str, repo_name: str, env_name: str) -> list[dict[str, Any]]:
+        return await self.rest_api.repo.get_environment_variables(org_id, repo_name, env_name)
+
+    async def update_environment_variable(
+        self, org_id: str, repo_name: str, env_name: str, variable_name: str, variable: dict[str, Any]
+    ) -> None:
+        if len(variable) > 0:
+            await self.rest_api.repo.update_environment_variable(org_id, repo_name, env_name, variable_name, variable)
+
+    async def add_environment_variable(self, org_id: str, repo_name: str, env_name: str, data: dict[str, str]) -> None:
+        await self.rest_api.repo.add_environment_variable(org_id, repo_name, env_name, data)
+
+    async def delete_environment_variable(self, org_id: str, repo_name: str, env_name: str, variable_name: str) -> None:
+        await self.rest_api.repo.delete_environment_variable(org_id, repo_name, env_name, variable_name)
+
     async def get_team_permissions(self, org_id: str) -> list[dict[str, Any]]:
         return await self.graphql_client.get_team_permissions(org_id)
 

--- a/otterdog/providers/github/rest/repo_client.py
+++ b/otterdog/providers/github/rest/repo_client.py
@@ -741,6 +741,166 @@ class RepoClient(RestClient):
 
         _logger.debug("removed repo environment '%s'", env_name)
 
+    async def get_environment_secrets(self, org_id: str, repo_name: str, env_name: str) -> list[dict[str, Any]]:
+        _logger.debug("retrieving secrets for environment '%s' of repo '%s/%s'", env_name, org_id, repo_name)
+
+        try:
+            status, body = await self.requester.request_raw(
+                "GET", f"/repos/{org_id}/{repo_name}/environments/{env_name}/secrets"
+            )
+            if status == 200:
+                return json.loads(body)["secrets"]
+            else:
+                return []
+        except GitHubException as ex:
+            raise RuntimeError(
+                f"failed retrieving secrets for environment '{env_name}' of repo '{org_id}/{repo_name}':\n{ex}"
+            ) from ex
+
+    async def update_environment_secret(
+        self, org_id: str, repo_name: str, env_name: str, secret_name: str, secret: dict[str, Any]
+    ) -> None:
+        _logger.debug(
+            "updating secret '%s' for environment '%s' of repo '%s/%s'", secret_name, env_name, org_id, repo_name
+        )
+
+        if "name" in secret:
+            secret.pop("name")
+
+        await self._encrypt_environment_secret_inplace(org_id, repo_name, env_name, secret)
+
+        status, _ = await self.requester.request_raw(
+            "PUT",
+            f"/repos/{org_id}/{repo_name}/environments/{env_name}/secrets/{secret_name}",
+            json.dumps(secret),
+        )
+
+        if status != 204:
+            raise RuntimeError(f"failed to update environment secret '{secret_name}'")
+
+        _logger.debug("updated environment secret '%s'", secret_name)
+
+    async def add_environment_secret(self, org_id: str, repo_name: str, env_name: str, data: dict[str, str]) -> None:
+        secret_name = data.pop("name")
+        _logger.debug(
+            "adding secret '%s' for environment '%s' of repo '%s/%s'", secret_name, env_name, org_id, repo_name
+        )
+
+        await self._encrypt_environment_secret_inplace(org_id, repo_name, env_name, data)
+
+        status, _ = await self.requester.request_raw(
+            "PUT",
+            f"/repos/{org_id}/{repo_name}/environments/{env_name}/secrets/{secret_name}",
+            json.dumps(data),
+        )
+
+        if status != 201:
+            raise RuntimeError(f"failed to add environment secret '{secret_name}'")
+
+        _logger.debug("added environment secret '%s'", secret_name)
+
+    async def _encrypt_environment_secret_inplace(
+        self, org_id: str, repo_name: str, env_name: str, data: dict[str, Any]
+    ) -> None:
+        value = data.pop("value")
+        key_id, public_key = await self.get_environment_public_key(org_id, repo_name, env_name)
+        data["encrypted_value"] = encrypt_value(public_key, value)
+        data["key_id"] = key_id
+
+    async def delete_environment_secret(self, org_id: str, repo_name: str, env_name: str, secret_name: str) -> None:
+        _logger.debug(
+            "deleting secret '%s' for environment '%s' of repo '%s/%s'", secret_name, env_name, org_id, repo_name
+        )
+
+        status, _ = await self.requester.request_raw(
+            "DELETE", f"/repos/{org_id}/{repo_name}/environments/{env_name}/secrets/{secret_name}"
+        )
+
+        if status != 204:
+            raise RuntimeError(f"failed to delete environment secret '{secret_name}'")
+
+        _logger.debug("removed environment secret '%s'", secret_name)
+
+    async def get_environment_public_key(self, org_id: str, repo_name: str, env_name: str) -> tuple[str, str]:
+        _logger.debug("retrieving public key for environment '%s' of repo '%s/%s'", env_name, org_id, repo_name)
+
+        try:
+            response = await self.requester.request_json(
+                "GET", f"/repos/{org_id}/{repo_name}/environments/{env_name}/secrets/public-key"
+            )
+            return response["key_id"], response["key"]
+        except GitHubException as ex:
+            raise RuntimeError(
+                f"failed retrieving public key for environment '{env_name}' of repo '{org_id}/{repo_name}':\n{ex}"
+            ) from ex
+
+    async def get_environment_variables(self, org_id: str, repo_name: str, env_name: str) -> list[dict[str, Any]]:
+        _logger.debug("retrieving variables for environment '%s' of repo '%s/%s'", env_name, org_id, repo_name)
+
+        try:
+            status, body = await self.requester.request_raw(
+                "GET", f"/repos/{org_id}/{repo_name}/environments/{env_name}/variables"
+            )
+            if status == 200:
+                return json.loads(body)["variables"]
+            else:
+                return []
+        except GitHubException as ex:
+            raise RuntimeError(
+                f"failed retrieving variables for environment '{env_name}' of repo '{org_id}/{repo_name}':\n{ex}"
+            ) from ex
+
+    async def update_environment_variable(
+        self, org_id: str, repo_name: str, env_name: str, variable_name: str, variable: dict[str, Any]
+    ) -> None:
+        _logger.debug(
+            "updating variable '%s' for environment '%s' of repo '%s/%s'", variable_name, env_name, org_id, repo_name
+        )
+
+        if "name" in variable:
+            variable.pop("name")
+
+        status, body = await self.requester.request_raw(
+            "PATCH",
+            f"/repos/{org_id}/{repo_name}/environments/{env_name}/variables/{variable_name}",
+            json.dumps(variable),
+        )
+        if status != 204:
+            raise RuntimeError(f"failed to update environment variable '{variable_name}': {body}")
+
+        _logger.debug("updated environment variable '%s'", variable_name)
+
+    async def add_environment_variable(self, org_id: str, repo_name: str, env_name: str, data: dict[str, str]) -> None:
+        variable_name = data.get("name")
+        _logger.debug(
+            "adding variable '%s' for environment '%s' of repo '%s/%s'", variable_name, env_name, org_id, repo_name
+        )
+
+        status, body = await self.requester.request_raw(
+            "POST",
+            f"/repos/{org_id}/{repo_name}/environments/{env_name}/variables",
+            json.dumps(data),
+        )
+
+        if status != 201:
+            raise RuntimeError(f"failed to add environment variable '{variable_name}': {body}")
+
+        _logger.debug("added environment variable '%s'", variable_name)
+
+    async def delete_environment_variable(self, org_id: str, repo_name: str, env_name: str, variable_name: str) -> None:
+        _logger.debug(
+            "deleting variable '%s' for environment '%s' of repo '%s/%s'", variable_name, env_name, org_id, repo_name
+        )
+
+        status, _ = await self.requester.request_raw(
+            "DELETE", f"/repos/{org_id}/{repo_name}/environments/{env_name}/variables/{variable_name}"
+        )
+
+        if status != 204:
+            raise RuntimeError(f"failed to delete environment variable '{variable_name}'")
+
+        _logger.debug("removed environment variable '%s'", variable_name)
+
     async def get_team_permissions(self, org_id: str, repo_name: str) -> list[dict[str, Any]]:
         _logger.debug("retrieving teams with permissions for repo '%s/%s'", org_id, repo_name)
 

--- a/otterdog/resources/schemas/environment-secret.json
+++ b/otterdog/resources/schemas/environment-secret.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$ref": "secret.json",
+  "type": "object",
+  "required": [ "name", "value" ],
+  "unevaluatedProperties": false
+}

--- a/otterdog/resources/schemas/environment-variable.json
+++ b/otterdog/resources/schemas/environment-variable.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+  "$ref": "variable.json",
+  "type": "object",
+  "required": [ "name", "value" ],
+  "unevaluatedProperties": false
+}

--- a/otterdog/resources/schemas/environment.json
+++ b/otterdog/resources/schemas/environment.json
@@ -9,10 +9,19 @@
       "type": "array",
       "items": { "type": "string" }
     },
+    "prevent_self_review": { "type": "boolean" },
     "deployment_branch_policy": { "type": "string" },
     "branch_policies": {
       "type": "array",
       "items": { "type": "string" }
+    },
+    "secrets": {
+      "type": "array",
+      "items": { "$ref": "environment-secret.json" }
+    },
+    "variables": {
+      "type": "array",
+      "items": { "$ref": "environment-variable.json" }
     }
   },
 

--- a/otterdog/webapp/home/routes.py
+++ b/otterdog/webapp/home/routes.py
@@ -341,6 +341,8 @@ async def defaults(project_name: str):
             ("repo-variable", "Repository Variable", f"{jsonnet_config.create_repo_variable}('<name>')"),
             ("repo-webhook", "Repository Webhook", f"{jsonnet_config.create_repo_webhook}('<url>')"),
             ("environment", "Environment", f"{jsonnet_config.create_environment}('<name>')"),
+            ("environment-secret", "Environment Secret", f"{jsonnet_config.create_environment_secret}('<name>')"),
+            ("environment-variable", "Environment Variable", f"{jsonnet_config.create_environment_variable}('<name>')"),
             ("bpr", "Branch Protection Rule", f"{jsonnet_config.create_branch_protection_rule}('<pattern>')"),
             ("repo-ruleset", "Repository Ruleset", f"{jsonnet_config.create_repo_ruleset}('<name>')"),
             ("ruleset-pull-request", "Pull Request Settings", f"{jsonnet_config.create_pull_request}()"),

--- a/tests/models/resources/github-environment-secret.json
+++ b/tests/models/resources/github-environment-secret.json
@@ -1,0 +1,5 @@
+{
+  "name": "ENV-SECRET",
+  "created_at": "2023-06-13T20:40:38Z",
+  "updated_at": "2023-06-21T11:58:31Z"
+}

--- a/tests/models/resources/github-environment-variable.json
+++ b/tests/models/resources/github-environment-variable.json
@@ -1,0 +1,6 @@
+{
+  "name": "ENV-VARIABLE",
+  "value": "some-value",
+  "created_at": "2023-06-13T20:40:38Z",
+  "updated_at": "2023-06-21T11:58:31Z"
+}

--- a/tests/models/resources/github-environment.json
+++ b/tests/models/resources/github-environment.json
@@ -12,6 +12,7 @@
       "id": 9174563,
       "node_id": "GA_kwDOI9xAhM4Ai_4j",
       "type": "required_reviewers",
+      "prevent_self_review": true,
       "reviewers": [
         {
           "type": "User",

--- a/tests/models/resources/otterdog-environment-secret.json
+++ b/tests/models/resources/otterdog-environment-secret.json
@@ -1,0 +1,4 @@
+{
+  "name": "ENV-SECRET",
+  "value": "1234"
+}

--- a/tests/models/resources/otterdog-environment-variable.json
+++ b/tests/models/resources/otterdog-environment-variable.json
@@ -1,0 +1,4 @@
+{
+  "name": "ENV-VARIABLE",
+  "value": "some-value"
+}

--- a/tests/models/resources/otterdog-environment.json
+++ b/tests/models/resources/otterdog-environment.json
@@ -5,9 +5,22 @@
     "@netomi",
     "@OtterdogTest/eclipsefdn-security"
   ],
+  "prevent_self_review": true,
   "deployment_branch_policy": "selected",
   "branch_policies": [
     "main",
     "develop/*"
+  ],
+  "secrets": [
+    {
+      "name": "ENV-SECRET",
+      "value": "1234"
+    }
+  ],
+  "variables": [
+    {
+      "name": "ENV-VARIABLE",
+      "value": "some-value"
+    }
   ]
 }

--- a/tests/models/resources/test-org/vendor/test-defaults/test-defaults.libsonnet
+++ b/tests/models/resources/test-org/vendor/test-defaults/test-defaults.libsonnet
@@ -246,6 +246,7 @@ local newEnvironment(name) = {
   name: name,
   wait_timer: 0,
   reviewers: [],
+  prevent_self_review: false,
   # Can be one of: all, protected_branches, branch_policies
   deployment_branch_policy: "all",
   branch_policies: [],

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -41,8 +41,17 @@ class EnvironmentTest(ModelTest):
         assert env.name == "linux"
         assert env.wait_timer == 15
         assert env.reviewers == ["@netomi", "@OtterdogTest/eclipsefdn-security"]
+        assert env.prevent_self_review is True
         assert env.deployment_branch_policy == "selected"
         assert env.branch_policies == ["main", "develop/*"]
+
+        assert len(env.secrets) == 1
+        assert env.secrets[0].name == "ENV-SECRET"
+        assert env.secrets[0].value == "1234"
+
+        assert len(env.variables) == 1
+        assert env.variables[0].name == "ENV-VARIABLE"
+        assert env.variables[0].value == "some-value"
 
     def test_load_from_provider(self):
         env = Environment.from_provider_data(self.org_id, self.provider_data)
@@ -52,16 +61,21 @@ class EnvironmentTest(ModelTest):
         assert env.name == "linux"
         assert env.wait_timer == 15
         assert env.reviewers == ["@netomi", "@OtterdogTest/eclipsefdn-security"]
+        assert env.prevent_self_review is True
         assert env.deployment_branch_policy == "selected"
         assert env.branch_policies == ["main", "develop/*"]
+
+        assert env.secrets == []
+        assert env.variables == []
 
     async def test_to_provider(self):
         env = Environment.from_model_data(self.model_data)
 
         provider_data = await env.to_provider_data(self.org_id, self.provider)
 
-        assert len(provider_data) == 5
+        assert len(provider_data) == 6
         assert provider_data["wait_timer"] == 15
+        assert provider_data["prevent_self_review"] is True
 
         assert query_json("reviewers[0].id", provider_data) == "id_netomi"
         assert query_json("reviewers[1].id", provider_data) == "id_OtterdogTest/eclipsefdn-security"

--- a/tests/models/test_environment_secret.py
+++ b/tests/models/test_environment_secret.py
@@ -1,0 +1,68 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from collections.abc import Mapping
+from typing import Any
+
+from otterdog.jsonnet import JsonnetConfig
+from otterdog.models import ModelObject
+from otterdog.models.environment_secret import EnvironmentSecret
+from otterdog.utils import Change
+
+from . import ModelTest
+
+
+class EnvironmentSecretTest(ModelTest):
+    def create_model(self, data: Mapping[str, Any]) -> ModelObject:
+        return EnvironmentSecret.from_model_data(data)
+
+    @property
+    def template_function(self) -> str:
+        return JsonnetConfig.create_environment_secret
+
+    @property
+    def model_data(self):
+        return self.load_json_resource("otterdog-environment-secret.json")
+
+    @property
+    def provider_data(self):
+        return self.load_json_resource("github-environment-secret.json")
+
+    def test_load_from_model(self):
+        secret = EnvironmentSecret.from_model_data(self.model_data)
+
+        assert secret.name == "ENV-SECRET"
+        assert secret.value == "1234"
+
+    def test_load_from_provider(self):
+        secret = EnvironmentSecret.from_provider_data(self.org_id, self.provider_data)
+
+        assert secret.name == "ENV-SECRET"
+        assert secret.value == "********"
+
+    def test_patch(self):
+        current = EnvironmentSecret.from_model_data(self.model_data)
+        default = EnvironmentSecret.from_model_data(self.model_data)
+
+        default.value = "5678"
+
+        patch = current.get_patch_to(default)
+
+        assert len(patch) == 1
+        assert patch["value"] == current.value
+
+    def test_difference(self):
+        current = EnvironmentSecret.from_model_data(self.model_data)
+        other = EnvironmentSecret.from_model_data(self.model_data)
+
+        other.value = "5678"
+
+        diff = current.get_difference_from(other)
+
+        assert len(diff) == 1
+        assert diff["value"] == Change(other.value, current.value)

--- a/tests/models/test_environment_variable.py
+++ b/tests/models/test_environment_variable.py
@@ -1,0 +1,68 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+from collections.abc import Mapping
+from typing import Any
+
+from otterdog.jsonnet import JsonnetConfig
+from otterdog.models import ModelObject
+from otterdog.models.environment_variable import EnvironmentVariable
+from otterdog.utils import Change
+
+from . import ModelTest
+
+
+class EnvironmentVariableTest(ModelTest):
+    def create_model(self, data: Mapping[str, Any]) -> ModelObject:
+        return EnvironmentVariable.from_model_data(data)
+
+    @property
+    def template_function(self) -> str:
+        return JsonnetConfig.create_environment_variable
+
+    @property
+    def model_data(self):
+        return self.load_json_resource("otterdog-environment-variable.json")
+
+    @property
+    def provider_data(self):
+        return self.load_json_resource("github-environment-variable.json")
+
+    def test_load_from_model(self):
+        variable = EnvironmentVariable.from_model_data(self.model_data)
+
+        assert variable.name == "ENV-VARIABLE"
+        assert variable.value == "some-value"
+
+    def test_load_from_provider(self):
+        variable = EnvironmentVariable.from_provider_data(self.org_id, self.provider_data)
+
+        assert variable.name == "ENV-VARIABLE"
+        assert variable.value == "some-value"
+
+    def test_patch(self):
+        current = EnvironmentVariable.from_model_data(self.model_data)
+        default = EnvironmentVariable.from_model_data(self.model_data)
+
+        default.value = "other-value"
+
+        patch = current.get_patch_to(default)
+
+        assert len(patch) == 1
+        assert patch["value"] == current.value
+
+    def test_difference(self):
+        current = EnvironmentVariable.from_model_data(self.model_data)
+        other = EnvironmentVariable.from_model_data(self.model_data)
+
+        other.value = "other-value"
+
+        diff = current.get_difference_from(other)
+
+        assert len(diff) == 1
+        assert diff["value"] == Change(other.value, current.value)

--- a/tests/providers/github/integration/helpers/model.py
+++ b/tests/providers/github/integration/helpers/model.py
@@ -9,6 +9,8 @@
 from otterdog.models import LivePatch, LivePatchContext, ModelObject
 from otterdog.models.custom_property import CustomProperty
 from otterdog.models.environment import Environment
+from otterdog.models.environment_secret import EnvironmentSecret
+from otterdog.models.environment_variable import EnvironmentVariable
 from otterdog.models.organization_secret import OrganizationSecret
 from otterdog.models.organization_settings import OrganizationSettings
 from otterdog.models.organization_variable import OrganizationVariable
@@ -54,6 +56,8 @@ class ModelForContext:
             self.repository = Repository.from_model_data({"name": repo_name})
         if env_name:
             self.environment = Environment.from_model_data({"name": env_name})
+            if repo_name:
+                self.environment.repo_name = repo_name
 
         self.live_patch_context = LivePatchContext(
             org_id=org_id,
@@ -98,8 +102,10 @@ class ModelForContext:
         """
 
         model_cls = determine_model_object(old, new)
-        if model_cls in {RepositorySecret, RepositoryVariable}:
+        if model_cls in {RepositorySecret, RepositoryVariable, Environment}:
             return self.repository
+        if model_cls in {EnvironmentSecret, EnvironmentVariable}:
+            return self.environment
         if model_cls in {OrganizationSecret, OrganizationVariable, CustomProperty}:
             return None  # Organization-level, no parent object
         raise ValueError(f"Unknown model class for parent: {model_cls}")

--- a/tests/providers/github/integration/test_environment_secrets.py
+++ b/tests/providers/github/integration/test_environment_secrets.py
@@ -1,0 +1,133 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+
+from otterdog.models.environment_secret import EnvironmentSecret
+
+from .conftest import GitHubProviderTestKit
+from .helpers.model import ModelForContext
+
+# Constants
+ORG_ID = "test-org"
+REPO_NAME = "test-repo"
+ENV_NAME = "test-env"
+
+GITHUB_SERVER_PUBLIC_KEY = "/Iag6O/YqKnJ8a1TuxcW4bMsIYs2LJ5RrOPVt9M0yUU="
+KEY_ID = "test_key_id"
+PLAINTEXT_SECRET = "my_secret_value"
+CIPHERTEXT = "FAKE_CIPHERTEXT"
+
+
+async def generate_patch_and_run_it(
+    github: GitHubProviderTestKit,
+    *,
+    old: EnvironmentSecret | None,
+    new: EnvironmentSecret | None,
+):
+    """Generate and apply a LivePatch in one call."""
+    # Further model objects are required for context, as the relevant ModelObjects cannot be standalone.
+    # This sets up a rather minimal context:
+    model = ModelForContext(ORG_ID, repo_name=REPO_NAME, env_name=ENV_NAME)
+
+    patch = model.generate_live_patch(old=old, new=new)
+    await patch.apply(ORG_ID, github.provider)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# CRUD operations for EnvironmentSecret
+# ---------------------------------------------------------------------------
+
+
+async def test_create(github: GitHubProviderTestKit):
+    github.fake_encryption((GITHUB_SERVER_PUBLIC_KEY, PLAINTEXT_SECRET), CIPHERTEXT)
+
+    # First of all the public key is fetched.
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/secrets/public-key",
+        response_json={"key_id": KEY_ID, "key": GITHUB_SERVER_PUBLIC_KEY},
+    )
+
+    # Next the secret is transmitted to GitHub in encrypted form.
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/secrets/TEST_SECRET",
+        request_json={"key_id": KEY_ID, "encrypted_value": CIPHERTEXT},
+        response_status=201,
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=None,
+        new=EnvironmentSecret(name="TEST_SECRET", value=PLAINTEXT_SECRET),
+    )
+
+
+async def test_read(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/secrets",
+        response_json={
+            "total_count": 2,
+            "secrets": [
+                {"name": "SECRET_ONE", "created_at": "2024-01-01T00:00:00Z", "updated_at": "2024-01-01T00:00:00Z"},
+                {"name": "SECRET_TWO", "created_at": "2024-01-02T00:00:00Z", "updated_at": "2024-01-02T00:00:00Z"},
+            ],
+        },
+    )
+
+    # Following two lines are taken from GitHubOrganization.load_from_provider().
+    # Organization loading is a big black box, so we cannot run it directly here.
+    data = await github.provider.get_environment_secrets(ORG_ID, REPO_NAME, ENV_NAME)
+    secrets = [EnvironmentSecret.from_provider_data(ORG_ID, d) for d in data]
+
+    # Secrets are not returned by GitHub API. Within the model they have a placeholder value.
+    magic_value = "********"
+    assert secrets == [
+        EnvironmentSecret(name="SECRET_ONE", value=magic_value),
+        EnvironmentSecret(name="SECRET_TWO", value=magic_value),
+    ]
+
+
+async def test_update(github: GitHubProviderTestKit):
+    github.fake_encryption((GITHUB_SERVER_PUBLIC_KEY, PLAINTEXT_SECRET), CIPHERTEXT)
+
+    # First of all the public key is fetched.
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/secrets/public-key",
+        response_json={"key_id": KEY_ID, "key": GITHUB_SERVER_PUBLIC_KEY},
+    )
+
+    # Next the secret is transmitted to GitHub in encrypted form.
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/secrets/TEST_SECRET",
+        request_json={"key_id": KEY_ID, "encrypted_value": CIPHERTEXT},
+        response_status=204,
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=EnvironmentSecret(name="TEST_SECRET", value="old_value"),
+        new=EnvironmentSecret(name="TEST_SECRET", value=PLAINTEXT_SECRET),
+    )
+
+
+async def test_delete(github: GitHubProviderTestKit):
+    github.http.expect(
+        "DELETE",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/secrets/TEST_SECRET",
+        response_status=204,
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=EnvironmentSecret(name="TEST_SECRET", value="secret_value"),
+        new=None,
+    )

--- a/tests/providers/github/integration/test_environment_variables.py
+++ b/tests/providers/github/integration/test_environment_variables.py
@@ -1,0 +1,116 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+
+from otterdog.models.environment_variable import EnvironmentVariable
+
+from .conftest import GitHubProviderTestKit
+from .helpers.model import ModelForContext
+
+# Constants
+ORG_ID = "test-org"
+REPO_NAME = "test-repo"
+ENV_NAME = "test-env"
+
+
+async def generate_patch_and_run_it(
+    github: GitHubProviderTestKit,
+    *,
+    old: EnvironmentVariable | None,
+    new: EnvironmentVariable | None,
+):
+    """Generate and apply a LivePatch in one call."""
+    # Further model objects are required for context, as the relevant ModelObjects cannot be standalone.
+    # This sets up a rather minimal context:
+    model = ModelForContext(ORG_ID, repo_name=REPO_NAME, env_name=ENV_NAME)
+
+    patch = model.generate_live_patch(old=old, new=new)
+    await patch.apply(ORG_ID, github.provider)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# CRUD operations for EnvironmentVariable
+# ---------------------------------------------------------------------------
+
+
+async def test_create(github: GitHubProviderTestKit):
+    github.http.expect(
+        "POST",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/variables",
+        request_json={"name": "TEST_VAR", "value": "variable_value"},
+        response_status=201,
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=None,
+        new=EnvironmentVariable(name="TEST_VAR", value="variable_value"),
+    )
+
+
+async def test_read(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/variables",
+        response_json={
+            "total_count": 2,
+            "variables": [
+                {
+                    "name": "VAR_ONE",
+                    "value": "value_one",
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "updated_at": "2024-01-01T00:00:00Z",
+                },
+                {
+                    "name": "VAR_TWO",
+                    "value": "value_two",
+                    "created_at": "2024-01-02T00:00:00Z",
+                    "updated_at": "2024-01-02T00:00:00Z",
+                },
+            ],
+        },
+    )
+
+    # Following two lines are taken from GitHubOrganization.load_from_provider().
+    # Organization loading is a big black box, so we cannot run it directly here.
+    data = await github.provider.get_environment_variables(ORG_ID, REPO_NAME, ENV_NAME)
+    variables = [EnvironmentVariable.from_provider_data(ORG_ID, data) for data in data]
+
+    assert variables == [
+        EnvironmentVariable(name="VAR_ONE", value="value_one"),
+        EnvironmentVariable(name="VAR_TWO", value="value_two"),
+    ]
+
+
+async def test_update(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PATCH",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/variables/TEST_VAR",
+        request_json={"value": "new_value"},
+        response_status=204,
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=EnvironmentVariable(name="TEST_VAR", value="old_value"),
+        new=EnvironmentVariable(name="TEST_VAR", value="new_value"),
+    )
+
+
+async def test_delete(github: GitHubProviderTestKit):
+    github.http.expect(
+        "DELETE",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}/variables/TEST_VAR",
+        response_status=204,
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=EnvironmentVariable(name="TEST_VAR", value="variable_value"),
+        new=None,
+    )

--- a/tests/providers/github/integration/test_environments.py
+++ b/tests/providers/github/integration/test_environments.py
@@ -1,0 +1,118 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+
+from otterdog.models.environment import Environment
+
+from .conftest import GitHubProviderTestKit
+from .helpers.model import ModelForContext
+
+# Constants
+ORG_ID = "test-org"
+REPO_NAME = "test-repo"
+ENV_NAME = "test-env"
+
+
+async def generate_patch_and_run_it(
+    github: GitHubProviderTestKit,
+    *,
+    old: Environment | None,
+    new: Environment | None,
+):
+    """Generate and apply a LivePatch in one call."""
+    # Further model objects are required for context, as the relevant ModelObjects cannot be standalone.
+    # This sets up a rather minimal context:
+    model = ModelForContext(ORG_ID, repo_name=REPO_NAME)
+
+    patch = model.generate_live_patch(old=old, new=new)
+    await patch.apply(ORG_ID, github.provider)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# CRUD operations for Environment, focusing on the "prevent_self_review" flag
+# ---------------------------------------------------------------------------
+
+
+async def test_create(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}",
+        request_json={"prevent_self_review": True},
+        response_json={"name": ENV_NAME},
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=None,
+        new=Environment.from_model_data({"name": ENV_NAME, "prevent_self_review": True}),
+    )
+
+
+async def test_read(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments",
+        response_json={
+            "total_count": 1,
+            "environments": [
+                {
+                    "id": 1,
+                    "node_id": "node_id_1",
+                    "name": ENV_NAME,
+                    "protection_rules": [
+                        {
+                            "id": 1,
+                            "node_id": "node_id_2",
+                            "type": "required_reviewers",
+                            "prevent_self_review": True,
+                            "reviewers": [],
+                        },
+                    ],
+                    "deployment_branch_policy": None,
+                },
+            ],
+        },
+    )
+
+    # Following two lines are taken from GitHubOrganization.load_from_provider().
+    # Organization loading is a big black box, so we cannot run it directly here.
+    data = await github.provider.get_repo_environments(ORG_ID, REPO_NAME)
+    environments = [Environment.from_provider_data(ORG_ID, d) for d in data]
+
+    assert len(environments) == 1
+    assert environments[0].name == ENV_NAME
+    assert environments[0].prevent_self_review is True
+
+
+async def test_update(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}",
+        request_json={"prevent_self_review": True},
+        response_json={"name": ENV_NAME},
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=Environment.from_model_data({"name": ENV_NAME, "prevent_self_review": False}),
+        new=Environment.from_model_data({"name": ENV_NAME, "prevent_self_review": True}),
+    )
+
+
+async def test_delete(github: GitHubProviderTestKit):
+    github.http.expect(
+        "DELETE",
+        f"/repos/{ORG_ID}/{REPO_NAME}/environments/{ENV_NAME}",
+        response_status=204,
+    )
+
+    await generate_patch_and_run_it(
+        github,
+        old=Environment.from_model_data({"name": ENV_NAME, "prevent_self_review": True}),
+        new=None,
+    )


### PR DESCRIPTION
Closes #537, closes #680.

- New EnvironmentSecret/EnvironmentVariable model classes
- Extended Environment with a repo_name bridging field, nested secrets/variables lists, get_model_objects, resolve_secrets/copy_secrets, and a generate_live_patch override that cascades to nested secrets/variables
- New REST client methods for GET/PUT/DELETE environment secrets and GET/POST/PATCH/DELETE environment variables, plus facade wrappers
- Repository.get_environment() helper and cascading resolve_secrets/copy_secrets
- New JsonnetConfig entries/default-config properties, jsonnet template functions, and JSON schema files
- Web UI resource registry entries
- New unit tests plus new integration tests with extended ModelForContext test helper
- Docs: New pages for environment variables/secrets