### PR TITLE
Workflow file parsing error

### DIFF
--- a/otterdog/webapp/tasks/blueprints/pinning/workflow_file.py
+++ b/otterdog/webapp/tasks/blueprints/pinning/workflow_file.py
@@ -21,7 +21,10 @@ class WorkflowFile:
     lines: list[str] = field(init=False)
 
     def __post_init__(self):
-        self.content = yaml.safe_load(self.raw_content)
+        try:
+            self.content = yaml.safe_load(self.raw_content)
+        except yaml.YAMLError as e:
+            raise RuntimeError(f"failed to parse workflow YAML: {e}") from e
         self.lines = self.raw_content.splitlines(keepends=True)
 
     def get_used_actions(self) -> list[str]:


### PR DESCRIPTION
Manage malformed workflow YAML files gracefully: [https://github.com/eclipse-uprotocol/up-kotlin/blob/main/.github/workflows/codeql.yml](https://github.com/eclipse-uprotocol/up-kotlin/blob/main/.github/workflows/codeql.yml)


```shell

2026-07-07 06:55:06.442 ] [10] [ERROR] failed to execute task 'PinWorkflowTask(repo='eclipse-uprotocol/up-kotlin')'
Traceback (most recent call last):
File "/app/otterdog/webapp/tasks/__init__.py", line 72, in execute
result = await self._execute()
^^^^^^^^^^^^^^^^^^^^^
File "/app/otterdog/webapp/tasks/blueprints/pin_workflow.py", line 56, in _execute
workflow = WorkflowFile(workflow_content)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "<string>", line 4, in __init__
File "/app/otterdog/webapp/tasks/blueprints/pinning/workflow_file.py", line 24, in __post_init__
self.content = yaml.safe_load(self.raw_content)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/__init__.py", line 125, in safe_load
return load(stream, SafeLoader)
^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/__init__.py", line 81, in load
return loader.get_single_data()
^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/constructor.py", line 49, in get_single_data
node = self.get_single_node()
^^^^^^^^^^^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/composer.py", line 36, in get_single_node
document = self.compose_document()
^^^^^^^^^^^^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/composer.py", line 55, in compose_document
node = self.compose_node(None, None)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/composer.py", line 84, in compose_node
node = self.compose_mapping_node(anchor)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/composer.py", line 127, in compose_mapping_node
while not self.check_event(MappingEndEvent):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/parser.py", line 98, in check_event
self.current_event = self.state()
^^^^^^^^^^^^
File "/app/.venv/lib/python3.12/site-packages/yaml/parser.py", line 438, in parse_block_mapping_key
raise ParserError("while parsing a block mapping", self.marks[-1],
yaml.parser.ParserError: while parsing a block mapping
in "<unicode string>", line 1, column 1:
name: "CodeQL"
^
expected <block end>, but found '<block mapping start>'
in "<unicode string>", line 3, column 9:
``