### PR TITLE
Handle invalid workflow YAML in PinWorkflowTask

### DIFF
--- a/otterdog/webapp/tasks/blueprints/pinning/workflow_file.py
+++ b/otterdog/webapp/tasks/blueprints/pinning/workflow_file.py
@@ -29,6 +29,8 @@ class WorkflowFile:
 
         # regular workflows
         for _k, v in self.content.get("jobs", {}).items():
+            if v is None:
+                continue
             # jobs.<job_id>.steps[*].uses
             for step in v.get("steps", []):
                 if "uses" in step:


### PR DESCRIPTION
Fixes crashes occurring in PinWorkflowTask when processing GitHub Actions workflow files.

```shell
[2026-07-07 06:55:05.302 ] [10] [ERROR] failed to execute task 'PinWorkflowTask(repo='eclipse-uprotocol/up-android-helloworld')'
Traceback (most recent call last):
File "/app/otterdog/webapp/tasks/__init__.py", line 72, in execute
result = await self._execute()
^^^^^^^^^^^^^^^^^^^^^
File "/app/otterdog/webapp/tasks/blueprints/pin_workflow.py", line 57, in _execute
pinned, pinned_lines = await self._pin_workflow(workflow)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/otterdog/webapp/tasks/blueprints/pin_workflow.py", line 101, in _pin_workflow
referenced_actions = set(workflow.get_used_actions())
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/otterdog/webapp/tasks/blueprints/pinning/workflow_file.py", line 33, in get_used_actions
for step in v.get("steps", []):
^^^^^
AttributeError: 'NoneType' object has no attribute 'get'


```