### PR TITLE
fix: stylesheet on 404 pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: otterdog
 site_description: Manage GitHub organizations at scale
 strict: true
-site_url: https://otterdog.readthedocs.io/
+site_url: !ENV [READTHEDOCS_CANONICAL_URL, "http://localhost:8000/"]
 
 theme:
   name: 'material'


### PR DESCRIPTION

Fix error loading stylesheet on 404 webpage.

test url: https://otterdog.readthedocs.io/en/latest/test

<img width="1641" height="906" alt="image" src="https://github.com/user-attachments/assets/c40dba4c-bbdb-4f89-97f0-f6dc7f2d6927" />

Instead of: 

<img width="1493" height="433" alt="image" src="https://github.com/user-attachments/assets/de859a8b-7a54-495b-b3a7-902d2a34502d" />

See official doc: https://docs.readthedocs.com/platform/stable/intro/mkdocs.html

