### PR TITLE
Make --author mandatory for open-pr

### DIFF
--- a/otterdog/cli.py
+++ b/otterdog/cli.py
@@ -333,7 +333,7 @@ def push_config(organizations: list[str], no_diff, force, message):
 @cli.command(cls=StdCommand, short_help="Opens a pull request for local configuration changes.")
 @click.option("-b", "--branch", required=True, help="branch name")
 @click.option("-t", "--title", required=True, help="PR title")
-@click.option("-a", "--author", help="GitHub handle of author")
+@click.option("-a", "--author", required=True, help="GitHub handle of author")
 def open_pr(organizations: list[str], branch, title, author):
     """
     Opens a pull request for local configuration changes in the corresponding config repo of an organization.

--- a/otterdog/operations/open_pull_request.py
+++ b/otterdog/operations/open_pull_request.py
@@ -80,7 +80,10 @@ class OpenPullRequestOperation(Operation):
 
             async with GitHubProvider(credentials) as provider:
                 rest_api = provider.rest_api
-
+                try:
+                    await rest_api.user.get_user_ids(self.author)
+                except RuntimeError as ex:
+                    raise RuntimeError(f"author '{self.author}' is not a valid GitHub user: {ex!s}") from ex
                 try:
                     default_branch = await rest_api.repo.get_default_branch(
                         org_config.github_id, org_config.config_repo
@@ -178,10 +181,7 @@ class OpenPullRequestOperation(Operation):
             branch_name,
         )
 
-        if self.author is not None:
-            body = f"This PR has been created automatically on behalf of @{self.author} using the otterdog cli."
-        else:
-            body = "This PR has been created automatically using the otterdog cli."
+        body = f"This PR has been created automatically on behalf of @{self.author} using the otterdog cli."
 
         pull_request_data = await rest_api.pull_request.create_pull_request(
             org_config.github_id,


### PR DESCRIPTION
Pull requests created with the Otterdog client `open-pr` do not always make it clear who originally requested or initiated the change.

For example:
https://github.com/eclipse-arrowhead/.eclipsefdn/pull/4

The GitHub pull request is opened by the account used by Otterdog, which makes it difficult to identify the actual author behind the requested changes.

For traceability and audit purposes, the `author` parameter should be mandatory when using the `open-pr` command.
