### PR TITLE
Handle mongodb uri with alternative authSource

### DIFF
--- a/otterdog/webapp/db/__init__.py
+++ b/otterdog/webapp/db/__init__.py
@@ -15,7 +15,7 @@ from quart import Quart
 from otterdog.utils import unwrap
 
 
-def _parse(mongo_uri: str) -> str:
+def _database_from_uri(mongo_uri: str) -> str:
     urlparsed = urlparse(mongo_uri)
     if urlparsed.scheme != "mongodb":
         raise RuntimeError(f"invalid mongo connection uri, no scheme: '{mongo_uri}'")
@@ -36,7 +36,7 @@ class Mongo:
 
     def init_app(self, app: Quart) -> None:
         mongo_uri = app.config["MONGO_URI"]
-        database = _parse(mongo_uri)
+        database = _database_from_uri(mongo_uri)
         self._client = AsyncIOMotorClient(mongo_uri)
         self._engine = AIOEngine(client=self._client, database=database)
 

--- a/otterdog/webapp/db/__init__.py
+++ b/otterdog/webapp/db/__init__.py
@@ -15,7 +15,7 @@ from quart import Quart
 from otterdog.utils import unwrap
 
 
-def _parse(mongo_uri: str) -> tuple[str, str]:
+def _parse(mongo_uri: str) -> str:
     urlparsed = urlparse(mongo_uri)
     if urlparsed.scheme != "mongodb":
         raise RuntimeError(f"invalid mongo connection uri, no scheme: '{mongo_uri}'")
@@ -24,10 +24,9 @@ def _parse(mongo_uri: str) -> tuple[str, str]:
         raise RuntimeError(f"invalid mongo connection uri, no database: '{mongo_uri}'")
 
     else:
-        server_uri = f"{urlparsed.scheme}://{urlparsed.netloc}"
         database = urlparsed.path[1:]
 
-    return server_uri, database
+    return database
 
 
 class Mongo:
@@ -36,9 +35,9 @@ class Mongo:
         self._engine: AIOEngine | None = None
 
     def init_app(self, app: Quart) -> None:
-        server_uri, database = _parse(app.config["MONGO_URI"])
-
-        self._client = AsyncIOMotorClient(server_uri)
+        mongo_uri = app.config["MONGO_URI"]
+        database = _parse(mongo_uri)
+        self._client = AsyncIOMotorClient(mongo_uri)
         self._engine = AIOEngine(client=self._client, database=database)
 
     @property

--- a/tests/webapp/db/test__init__.py
+++ b/tests/webapp/db/test__init__.py
@@ -12,22 +12,22 @@ from webapp.db import _parse
 @pytest.mark.parametrize(
     "mongodb_url, expected_result, expected_error",
     [
-        ("mongodb://root:secret@mongodb:27017/otterdog", ("mongodb://root:secret@mongodb:27017", "otterdog"), None),
-        ("mongodb://mongodb:27017/otterdog", ("mongodb://mongodb:27017", "otterdog"), None),
+        ("mongodb://root:secret@mongodb:27017/otterdog", "otterdog", None),
+        ("mongodb://mongodb:27017/otterdog", "otterdog", None),
         (
             "mongodb://root:secret@otterdog-mongodb.default.svc.cluster.local:27017/otterdog",
-            ("mongodb://root:secret@otterdog-mongodb.default.svc.cluster.local:27017", "otterdog"),
+            "otterdog",
             None,
         ),
         (
             "mongodb://otterdog-mongodb.default.svc.cluster.local:27017/otterdog",
-            ("mongodb://otterdog-mongodb.default.svc.cluster.local:27017", "otterdog"),
+            "otterdog",
             None,
         ),
-        ("mongodb://mongodb.example.com:27017/otterdog", ("mongodb://mongodb.example.com:27017", "otterdog"), None),
+        ("mongodb://mongodb.example.com:27017/otterdog", "otterdog", None),
         (
             "mongodb://:secret@mongodb.example.com:27017/otterdog",
-            ("mongodb://:secret@mongodb.example.com:27017", "otterdog"),
+            "otterdog",
             None,
         ),
         ("mongodb://mongodb:27017", None, "invalid mongo connection uri, no database"),

--- a/tests/webapp/db/test__init__.py
+++ b/tests/webapp/db/test__init__.py
@@ -5,8 +5,12 @@
 #  which is available at http://www.eclipse.org/legal/epl-v20.html
 #  SPDX-License-Identifier: EPL-2.0
 #  *******************************************************************************
+from unittest.mock import MagicMock
+
 import pytest
-from webapp.db import _parse
+import webapp.db as db_module
+from quart import Quart
+from webapp.db import Mongo, _parse
 
 
 @pytest.mark.parametrize(
@@ -43,3 +47,26 @@ def test__parse(mongodb_url, expected_result, expected_error):
     else:
         result = _parse(mongodb_url)
         assert result == expected_result
+
+
+def test_init_app_passes_full_uri(monkeypatch):
+    mongo_uri = "mongodb://mongodb:27017/otterdog"
+
+    captured_uris = []
+    mock_client = MagicMock()
+
+    def mock_motor_client(uri, *args, **kwargs):
+        captured_uris.append(uri)
+        return mock_client
+
+    monkeypatch.setattr(db_module, "AsyncIOMotorClient", mock_motor_client)
+    monkeypatch.setattr(db_module, "AIOEngine", MagicMock())
+
+    app = Quart(__name__)
+    app.config["MONGO_URI"] = mongo_uri
+
+    mongo = Mongo()
+    mongo.init_app(app)
+
+    assert len(captured_uris) == 1
+    assert captured_uris[0] == mongo_uri

--- a/tests/webapp/db/test__init__.py
+++ b/tests/webapp/db/test__init__.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 import webapp.db as db_module
 from quart import Quart
-from webapp.db import Mongo, _parse
+from webapp.db import Mongo, _database_from_uri
 
 
 @pytest.mark.parametrize(
@@ -38,14 +38,14 @@ from webapp.db import Mongo, _parse
         ("mongodb:27017", None, "invalid mongo connection uri, no scheme"),
     ],
 )
-def test__parse(mongodb_url, expected_result, expected_error):
+def test__database_from_uri(mongodb_url, expected_result, expected_error):
     if expected_error:
         with pytest.raises(RuntimeError) as err:
-            _parse(mongodb_url)
+            _database_from_uri(mongodb_url)
             assert expected_error in str(err)
 
     else:
-        result = _parse(mongodb_url)
+        result = _database_from_uri(mongodb_url)
         assert result == expected_result
 
 


### PR DESCRIPTION
Pass the full URI so PyMongo uses the database path as authSource.

Stripping the path would default authSource to 'admin' causing auth failure for non-admin users.