### PR TITLE
Failfast when required configuration is missing, empty or not trim

### DIFF
--- a/otterdog/webapp/config.py
+++ b/otterdog/webapp/config.py
@@ -11,6 +11,38 @@ import secrets
 
 from decouple import config  # type: ignore
 
+# Settings that must never resolve to an empty value: they are either used
+# to build outgoing requests/identifiers (URLs, hostnames, commit status
+# contexts) or are otherwise required for the application to function.
+REQUIRED_NON_EMPTY_SETTINGS = (
+    "BASE_URL",
+    "ASSETS_ROOT",
+    "APP_ROOT",
+    "MONGO_URI",
+    "REDIS_URI",
+    "GHPROXY_URI",
+    "GITHUB_ADMIN_TEAMS",
+    "GITHUB_WEBHOOK_ENDPOINT",
+    "GITHUB_WEBHOOK_VALIDATION_CONTEXT",
+    "GITHUB_WEBHOOK_SYNC_CONTEXT",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_PRIVATE_KEY",
+    "PROJECTS_BASE_URL",
+    "DEPENDENCY_TRACK_URL",
+    "DEPENDENCY_TRACK_TOKEN",
+    "OTTERDOG_CONFIG_OWNER",
+    "OTTERDOG_CONFIG_REPO",
+    "OTTERDOG_CONFIG_PATH",
+    "OTTERDOG_CONFIG_TOKEN",
+)
+
+
+def validate_required_settings(config_cls: type) -> None:
+    """Raise a ValueError if any setting in REQUIRED_NON_EMPTY_SETTINGS is empty on config_cls."""
+    for name in REQUIRED_NON_EMPTY_SETTINGS:
+        if not getattr(config_cls, name, None):
+            raise ValueError(f"{name} must not be empty")
+
 
 class AppConfig:
     QUART_APP = "otterdog.webapp"
@@ -58,6 +90,9 @@ class AppConfig:
     DEPENDENCY_TRACK_TOKEN = config("DEPENDENCY_TRACK_TOKEN")
 
 
+validate_required_settings(AppConfig)
+
+
 class ProductionConfig(AppConfig):
     DEBUG = False
 
@@ -80,6 +115,9 @@ class TestingConfig(AppConfig):
     DB_ROOT = os.path.join(APP_ROOT, "db")
 
     MONGO_URI = "mongodb://localhost:27017/otterdog"
+
+
+validate_required_settings(TestingConfig)
 
 
 # Load all possible configurations

--- a/otterdog/webapp/config.py
+++ b/otterdog/webapp/config.py
@@ -9,7 +9,14 @@
 import os
 import secrets
 
-from decouple import config  # type: ignore
+from decouple import config as _decouple_config  # type: ignore
+
+
+def config(*args, **kwargs):
+    """Wrapper around decouple's config() that strips leading/trailing whitespace from string values."""
+    value = _decouple_config(*args, **kwargs)
+    return value.strip() if isinstance(value, str) else value
+
 
 # Settings that must never resolve to an empty value: they are either used
 # to build outgoing requests/identifiers (URLs, hostnames, commit status

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -6,7 +6,22 @@
 #  SPDX-License-Identifier: EPL-2.0
 #  *******************************************************************************
 
+import os
+
 import pytest
+
+# Dummy values for settings that decouple/otterdog.webapp.config requires but have no
+# built-in default, so the test suite never depends on a developer's local .env file.
+os.environ.setdefault("BASE_URL", "http://localhost")
+os.environ.setdefault("APP_ROOT", "./approot")
+os.environ.setdefault("GITHUB_APP_ID", "dummy-app-id")
+os.environ.setdefault("GITHUB_APP_PRIVATE_KEY", "dummy-private-key")
+os.environ.setdefault("DEPENDENCY_TRACK_URL", "http://localhost/dependency-track")
+os.environ.setdefault("DEPENDENCY_TRACK_TOKEN", "dummy-dependency-track-token")
+os.environ.setdefault("OTTERDOG_CONFIG_OWNER", "dummy-owner")
+os.environ.setdefault("OTTERDOG_CONFIG_REPO", "dummy-repo")
+os.environ.setdefault("OTTERDOG_CONFIG_PATH", "dummy-path")
+os.environ.setdefault("OTTERDOG_CONFIG_TOKEN", "dummy-config-token")
 
 from otterdog.webapp import create_app
 

--- a/tests/webapp/test_config.py
+++ b/tests/webapp/test_config.py
@@ -1,0 +1,61 @@
+#  *******************************************************************************
+#  Copyright (c) 2025 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+import pytest
+
+from otterdog.webapp.config import (
+    REQUIRED_NON_EMPTY_SETTINGS,
+    TestingConfig,
+    config,
+    validate_required_settings,
+)
+
+
+def test_config_strips_whitespace_from_string_values(monkeypatch):
+    monkeypatch.setenv("SOME_TEST_SETTING", "  value-with-spaces  \n")
+    assert config("SOME_TEST_SETTING") == "value-with-spaces"
+
+
+def test_config_leaves_non_string_defaults_untouched(monkeypatch):
+    monkeypatch.delenv("SOME_MISSING_SETTING", raising=False)
+    assert config("SOME_MISSING_SETTING", default=False) is False
+
+
+def _stub_config(**overrides):
+    """A config class with every required setting set to a dummy value, independent of any .env file."""
+    values = {name: f"dummy-{name}" for name in REQUIRED_NON_EMPTY_SETTINGS}
+    values.update(overrides)
+    return type("StubConfig", (), values)
+
+
+def test_validate_required_settings_accepts_fully_populated_config():
+    validate_required_settings(_stub_config())
+
+
+def test_required_settings_are_defined_on_testing_config():
+    # guards against typos in REQUIRED_NON_EMPTY_SETTINGS not matching a real config attribute
+    for name in REQUIRED_NON_EMPTY_SETTINGS:
+        assert hasattr(TestingConfig, name), f"{name} is not a valid config attribute"
+
+
+@pytest.mark.parametrize("empty_value", ["", None])
+def test_validate_required_settings_rejects_empty_values(empty_value):
+    name = REQUIRED_NON_EMPTY_SETTINGS[0]
+    config_cls = _stub_config(**{name: empty_value})
+
+    with pytest.raises(ValueError, match=name):
+        validate_required_settings(config_cls)
+
+
+def test_validate_required_settings_rejects_missing_attribute():
+    name = REQUIRED_NON_EMPTY_SETTINGS[0]
+    values = {n: f"dummy-{n}" for n in REQUIRED_NON_EMPTY_SETTINGS if n != name}
+    config_cls = type("StubConfig", (), values)
+
+    with pytest.raises(ValueError, match=name):
+        validate_required_settings(config_cls)


### PR DESCRIPTION
Otterdog should validate its configuration during application startup and fail immediately when a required setting is missing or empty.

Currently, missing configuration values may only cause failures later at runtime, making deployment issues harder to identify and diagnose.

The application should:
* Validate all required configuration values during startup.
* Treat missing, empty as invalid.
* Log a clear error listing the invalid configuration keys.

The following configuration values should initially be considered mandatory:

```text
BASE_URL
ASSETS_ROOT
APP_ROOT
MONGO_URI
REDIS_URI
GHPROXY_URI
GITHUB_ADMIN_TEAMS
GITHUB_WEBHOOK_ENDPOINT
GITHUB_WEBHOOK_VALIDATION_CONTEXT
GITHUB_WEBHOOK_SYNC_CONTEXT
GITHUB_APP_ID
GITHUB_APP_PRIVATE_KEY
PROJECTS_BASE_URL
DEPENDENCY_TRACK_URL
DEPENDENCY_TRACK_TOKEN
OTTERDOG_CONFIG_OWNER
OTTERDOG_CONFIG_REPO
OTTERDOG_CONFIG_PATH
OTTERDOG_CONFIG_TOKEN
```