### PR TITLE
Manage already deleted branch by github

### DIFF
--- a/otterdog/models/organization_ruleset.py
+++ b/otterdog/models/organization_ruleset.py
@@ -42,7 +42,6 @@ class OrganizationRuleset(Ruleset):
         return f"orgs.{jsonnet_config.create_org_ruleset}"
 
     def validate(self, context: ValidationContext, parent_object: Any) -> None:
-
         super().validate(context, parent_object)
 
         repositories = cast("GitHubOrganization", context.root_object).repositories

--- a/otterdog/models/repository.py
+++ b/otterdog/models/repository.py
@@ -323,7 +323,6 @@ class Repository(ModelObject):
         )
 
     async def validate_code_scanning_languages(self, context: ValidationContext, parent_object: Any) -> None:
-
         # Only validate if provider is available and validation is required
         if self.requires_language_validation() and context.provider is not None:
             provider = context.provider
@@ -379,7 +378,6 @@ class Repository(ModelObject):
                 )
 
     def validate(self, context: ValidationContext, parent_object: Any) -> None:
-
         github_id = cast("GitHubOrganization", parent_object).github_id
         org_settings = cast("GitHubOrganization", parent_object).settings
 

--- a/otterdog/models/ruleset.py
+++ b/otterdog/models/ruleset.py
@@ -361,7 +361,6 @@ class Ruleset(ModelObject, abc.ABC):
     _inverted_roles: ClassVar[dict[str, str]] = {v: k for k, v in _roles.items()}
 
     def validate(self, context: ValidationContext, parent_object: Any) -> None:
-
         org_settings = cast("GitHubOrganization", context.root_object).settings
 
         if is_set_and_valid(self.target):

--- a/otterdog/providers/github/rest/reference_client.py
+++ b/otterdog/providers/github/rest/reference_client.py
@@ -60,7 +60,21 @@ class ReferenceClient(RestClient):
         status, body = await self.requester.request_raw("DELETE", f"/repos/{org_id}/{repo_name}/git/{full_ref}")
         if status == 204:
             return True
-        elif status in (409, 422):
+        elif status == 404:
+            _logger.warning("reference '%s' in repo '%s/%s' does not exist, nothing to delete", ref, org_id, repo_name)
+            return False
+        elif status == 409:
+            _logger.warning(
+                "conflict deleting reference '%s' in repo '%s/%s', ref might be protected or in use",
+                ref,
+                org_id,
+                repo_name,
+            )
+            return False
+        elif status == 422:
+            _logger.warning(
+                "unprocessable request while deleting reference '%s' in repo '%s/%s'", ref, org_id, repo_name
+            )
             return False
         else:
             raise RuntimeError(f"failed deleting reference '{ref}' in repo '{org_id}/{repo_name}'\n{status}: {body}")

--- a/otterdog/providers/github/rest/repo_client.py
+++ b/otterdog/providers/github/rest/repo_client.py
@@ -910,7 +910,6 @@ class RepoClient(RestClient):
             raise RuntimeError(f"failed getting team permissions for repo '{org_id}/{repo_name}':\n{ex}") from ex
 
     async def update_team_permission(self, org_id: str, repo_name: str, team_name: str, team_permission: str) -> None:
-
         status, _ = await self.requester.request_raw(
             "PUT",
             f"/orgs/{org_id}/teams/{team_name}/repos/{org_id}/{repo_name}",

--- a/otterdog/utils.py
+++ b/otterdog/utils.py
@@ -173,7 +173,6 @@ def _diff_list(list1: list[T], list2: list[T]) -> list[T]:
 def write_patch_object_as_json(
     diff_object: dict[str, Any], printer: IndentingPrinter, close_object: bool = True
 ) -> None:
-
     # Local helper function to safely quote keys for jsonnet output.
     # jsonnet allows unquoted keys only if they match ^[A-Za-z_][A-Za-z0-9_]*$.
     def quote_key(key: str) -> str:

--- a/otterdog/webapp/tasks/merge_pull_request.py
+++ b/otterdog/webapp/tasks/merge_pull_request.py
@@ -37,7 +37,6 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
         )
 
     async def _pre_execute_and_return_problems(self) -> list[str]:
-
         pr_model = await find_pull_request(self.org_id, self.repo_name, self.pull_request_number)
         if pr_model is None:
             raise RuntimeError(


### PR DESCRIPTION
GitHub may have already deleted the branch by the time `DeleteBranchTask` runs, causing the task to receive a `404 Not Found` response.

This PR handles this situation gracefully and prevents unnecessary stack traces such as the following:

```shell
2026-07-29 15:07:55.414 ] [11] [ERROR] failed to execute task 'DeleteBranchTask(repo='eclipse-cbi/eclipse-cbi-tycho-example', ref='otterdog/blueprint/pin-workflows')'
Traceback (most recent call last):
File "/app/otterdog/webapp/tasks/__init__.py", line 72, in execute
result = await self._execute()
^^^^^^^^^^^^^^^^^^^^^
File "/app/otterdog/webapp/tasks/delete_branch.py", line 38, in _execute
await rest_api.reference.delete_reference(self.org_id, self.repo_name, self.ref)
File "/app/otterdog/providers/github/rest/reference_client.py", line 66, in delete_reference
raise RuntimeError(f"failed deleting reference '{ref}' in repo '{org_id}/{repo_name}'\n{status}: {body}")
RuntimeError: failed deleting reference 'otterdog/blueprint/pin-workflows' in repo 'eclipse-cbi/eclipse-cbi-tycho-example'
404: {"message":"Reference does not exist","documentation_url":"https://docs.github.com/rest/git/refs#delete-a-reference","status":"404"}
```