### PR TITLE
Potential memory leak in macos large runners policy

### DIFF
--- a/otterdog/webapp/policies/macos_large_runners.py
+++ b/otterdog/webapp/policies/macos_large_runners.py
@@ -46,11 +46,8 @@ class MacOSLargeRunnersUsagePolicy(Policy):
 
             run_id = payload.run_id
 
-            rest_api = await get_rest_api_for_installation(installation_id)
-            try:
+            async with await get_rest_api_for_installation(installation_id) as rest_api:
                 cancelled = await rest_api.action.cancel_workflow_run(github_id, repo_name, run_id)
-            finally:
-                await rest_api.close()
             logger.info(f"cancelled workflow run #{run_id} in repo '{github_id}/{repo_name}': success={cancelled}")
 
         await self._update_status(github_id, uses_restricted_runner, permitted)

--- a/otterdog/webapp/policies/macos_large_runners.py
+++ b/otterdog/webapp/policies/macos_large_runners.py
@@ -47,7 +47,10 @@ class MacOSLargeRunnersUsagePolicy(Policy):
             run_id = payload.run_id
 
             rest_api = await get_rest_api_for_installation(installation_id)
-            cancelled = await rest_api.action.cancel_workflow_run(github_id, repo_name, run_id)
+            try:
+                cancelled = await rest_api.action.cancel_workflow_run(github_id, repo_name, run_id)
+            finally:
+                await rest_api.close()
             logger.info(f"cancelled workflow run #{run_id} in repo '{github_id}/{repo_name}': success={cancelled}")
 
         await self._update_status(github_id, uses_restricted_runner, permitted)


### PR DESCRIPTION
A potential memory leak was identified in the web application after repeated restarts caused by OOM in the cluster.

Claude helped trace the issue to the macOS large runner API request, where resource cleanup was not properly handled in a `finally` block.

This issue is expected to be the root cause of the memory leak. Further investigation will be required if OOM events continue after the fix is deployed.


<img width="1386" height="212" alt="image" src="https://github.com/user-attachments/assets/2a369665-aa64-4c2d-a814-35b22ae4cb03" />

