### PR TITLE
Add GITHUB_APPROVAL_TEAMS, handle configurable approval teams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ OTTERDOG_CONFIG_PATH=otterdog.json
 OTTERDOG_CONFIG_TOKEN=<your GH token>
 
 GITHUB_ADMIN_TEAMS=eclipsefdn-security,eclipsefdn-releng
+GITHUB_APPROVAL_TEAMS=project-leads$
 GITHUB_WEBHOOK_ENDPOINT=/github-webhook/receive
 GITHUB_WEBHOOK_SECRET=<your secret>
 GITHUB_WEBHOOK_VALIDATION_CONTEXT=eclipsefdn/otterdog-validation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build webapp assets
         working-directory: otterdog/webapp/static
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build
 
       # Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ permissions:
 
 env:
   LATEST_PY_VERSION: '3.12'
-  POETRY_VERSION: '2.0.1'
+  POETRY_VERSION: '2.4.1'
+  NODE_VERSION: '26'
 
 jobs:
   test:
@@ -47,6 +48,19 @@ jobs:
       - name: Install dependencies
         #if: steps.cache.outputs.cache-hit != 'true'
         run: poetry install -v --without=dev,typing,docs
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: otterdog/webapp/static/package-lock.json
+
+      # Build webapp static assets so create_app() finds manifest.json
+      - name: Build webapp assets
+        working-directory: otterdog/webapp/static
+        run: |
+          npm ci
+          npm run build
 
       # Run tests
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ dev-webapp-tunnel-local: init-minikube clean-ingress-finalizers clean-tailscale-
 
 dev-webapp-ngrok: init-minikube clean-ingress-finalizers  ## Run full stack development (includes webapp), exposed via ngrok
 	eval $$(minikube -p minikube docker-env)
-	skaffold dev --filename=dev/skaffold.yaml --profile dev-ngrok --cleanup=false
+	skaffold dev --filename=dev/skaffold.yaml --profile dev-ngrok --cleanup=true
 
 dev-webapp-ngrok-local: init-minikube clean-ingress-finalizers  ## Run full stack development (includes webapp), exposed via ngrok, using local Helm chart checkout
 	eval $$(minikube -p minikube docker-env)

--- a/TESTING.md
+++ b/TESTING.md
@@ -100,6 +100,7 @@ OTTERDOG_CONFIG_PATH=<Path to the otterdog.json, e.g. otterdog.json>
 OTTERDOG_CONFIG_TOKEN=<a valid GitHub token, no need for any permissions, just for rate limit purposes>
 
 GITHUB_ADMIN_TEAMS=<comma separated list of teams>
+GITHUB_APPROVAL_TEAMS=<comma separated list of team slugs and/or regexes (matched via re.search against a team slug) to decide if its approval counts towards the required approvals, e.g. project-leads,.*-committers$>
 GITHUB_WEBHOOK_ENDPOINT=/github-webhook/receive
 GITHUB_WEBHOOK_SECRET=<the webhook secret as configured for the GitHub App>
 GITHUB_WEBHOOK_VALIDATION_CONTEXT=<the validation context, e.g. otterdog/otterdog-validation>

--- a/TESTING.md
+++ b/TESTING.md
@@ -100,7 +100,11 @@ OTTERDOG_CONFIG_PATH=<Path to the otterdog.json, e.g. otterdog.json>
 OTTERDOG_CONFIG_TOKEN=<a valid GitHub token, no need for any permissions, just for rate limit purposes>
 
 GITHUB_ADMIN_TEAMS=<comma separated list of teams>
+# can be overridden per organization via the "admin_teams" key in its otterdog.json entry
+# accepts either a single string ("otterdog-admins") or a list (["otterdog-admins", "some-other-team"])
 GITHUB_APPROVAL_TEAMS=<comma separated list of team slugs and/or regexes (matched via re.search against a team slug) to decide if its approval counts towards the required approvals, e.g. project-leads,.*-committers$>
+# can be overridden per organization via the "approval_teams" key in its otterdog.json entry
+# accepts either a single string ("project-leads$") or a list (["test-team", "project-leads", ".*-committers$"])
 GITHUB_WEBHOOK_ENDPOINT=/github-webhook/receive
 GITHUB_WEBHOOK_SECRET=<the webhook secret as configured for the GitHub App>
 GITHUB_WEBHOOK_VALIDATION_CONTEXT=<the validation context, e.g. otterdog/otterdog-validation>

--- a/otterdog/config.py
+++ b/otterdog/config.py
@@ -55,6 +55,8 @@ class OrganizationConfig:
         base_template: str,
         jsonnet_config: JsonnetConfig,
         credential_data: dict[str, Any],
+        approval_teams: str | None = None,
+        admin_teams: str | None = None,
     ):
         self._name = name
         self._github_id = github_id
@@ -62,6 +64,8 @@ class OrganizationConfig:
         self._base_template = base_template
         self._jsonnet_config = jsonnet_config
         self._credential_data = credential_data
+        self._approval_teams = approval_teams
+        self._admin_teams = admin_teams
 
     @property
     def name(self):
@@ -82,6 +86,14 @@ class OrganizationConfig:
     @property
     def jsonnet_config(self) -> JsonnetConfig:
         return self._jsonnet_config
+
+    @property
+    def approval_teams(self) -> str | None:
+        return self._approval_teams
+
+    @property
+    def admin_teams(self) -> str | None:
+        return self._admin_teams
 
     @property
     def credential_data(self) -> dict[str, Any]:
@@ -110,6 +122,9 @@ class OrganizationConfig:
         config_repo = data.get("config_repo", otterdog_config.default_config_repo)
         base_template = data.get("base_template", otterdog_config.default_base_template)
 
+        approval_teams = cls._normalize_team_list(data.get("approval_teams"), "approval_teams", name)
+        admin_teams = cls._normalize_team_list(data.get("admin_teams"), "admin_teams", name)
+
         jsonnet_config = JsonnetConfig(
             github_id,
             otterdog_config.jsonnet_base_dir,
@@ -117,11 +132,35 @@ class OrganizationConfig:
             otterdog_config.local_mode,
         )
 
-        data = data.get("credentials", {})
-        if data is None:
+        credentials = data.get("credentials", {})
+        if credentials is None:
             raise RuntimeError(f"missing required credentials for organization config with name '{name}'")
 
-        return cls(name, github_id, config_repo, base_template, jsonnet_config, data)
+        return cls(
+            name,
+            github_id,
+            config_repo,
+            base_template,
+            jsonnet_config,
+            credentials,
+            approval_teams,
+            admin_teams,
+        )
+
+    @staticmethod
+    def _normalize_team_list(value: Any, key: str, org_name: str) -> str | None:
+        """Accepts either a plain string ("project-leads$") or a list of strings
+        (["test-team", "project-leads", ".*-committers$"]) for a comma-separated
+        team-pattern config entry and normalizes it to a single comma-joined string."""
+        if value is None or isinstance(value, str):
+            return value
+        elif isinstance(value, list):
+            return ",".join(str(entry) for entry in value)
+        else:
+            raise RuntimeError(
+                f"invalid '{key}' for organization config with name '{org_name}': "
+                f"expected a string or a list of strings, got {type(value)}"
+            )
 
     @classmethod
     def of(

--- a/otterdog/webapp/config.py
+++ b/otterdog/webapp/config.py
@@ -29,6 +29,7 @@ REQUIRED_NON_EMPTY_SETTINGS = (
     "REDIS_URI",
     "GHPROXY_URI",
     "GITHUB_ADMIN_TEAMS",
+    "GITHUB_APPROVAL_TEAMS",
     "GITHUB_WEBHOOK_ENDPOINT",
     "GITHUB_WEBHOOK_VALIDATION_CONTEXT",
     "GITHUB_WEBHOOK_SYNC_CONTEXT",
@@ -79,6 +80,10 @@ class AppConfig:
         SECRET_KEY = secrets.token_hex(16)
 
     GITHUB_ADMIN_TEAMS = config("GITHUB_ADMIN_TEAMS", default="otterdog-admins")
+    # Comma-separated list of entries matched (via re.search) against a user's team slugs to
+    # decide whether their approval satisfies the "required approvals" check for auto-merge.
+    # Each entry can be a plain team slug or a regex, e.g. "project-leads,.*-committers$".
+    GITHUB_APPROVAL_TEAMS = config("GITHUB_APPROVAL_TEAMS", default="project-leads$")
     GITHUB_WEBHOOK_ENDPOINT = config("GITHUB_WEBHOOK_ENDPOINT", default="/github-webhook/receive")
     GITHUB_WEBHOOK_SECRET = config("GITHUB_WEBHOOK_SECRET", default=None)
     GITHUB_WEBHOOK_VALIDATION_CONTEXT = config("GITHUB_WEBHOOK_VALIDATION_CONTEXT", default="otterdog-validate")

--- a/otterdog/webapp/db/models.py
+++ b/otterdog/webapp/db/models.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from logging import getLogger
 from typing import Any
 
 from odmantic import EmbeddedModel, Field, Model
 
 from otterdog.webapp.utils import current_utc_time
+
+logger = getLogger(__name__)
 
 
 class InstallationStatus(StrEnum):
@@ -33,6 +36,8 @@ class InstallationModel(Model):
     installation_status: InstallationStatus
     config_repo: str | None = None
     base_template: str | None = None
+    approval_teams: str | None = None
+    admin_teams: str | None = None
 
 
 class TaskStatus(StrEnum):
@@ -109,61 +114,92 @@ class PullRequestModel(Model):
     closed_at: datetime | None = None
     merged_at: datetime | None = Field(index=True, default=None)
 
-    def automerge_problems(self, matching_teams: list[str] | None = None) -> list[str]:
+    async def automerge_problems(self, matching_teams: list[str] | None = None) -> list[str]:
         """
         matching_teams, when passed, is the list of team slugs in the org that were
         actually resolved (via the GitHub API) to match one of the entries in
-        GITHUB_APPROVAL_TEAMS. Left as None when the caller didn't resolve it (e.g. a
-        plain boolean check), in which case the raw patterns are shown instead of a
-        concrete team name.
+        GITHUB_APPROVAL_TEAMS (or its per-organization override). Left as None when
+        the caller didn't resolve it (e.g. a plain boolean check), in which case the
+        raw patterns are shown instead of a concrete team name.
         """
+        logger.debug(
+            "automerge_problems for pull request '%s': status=%s, draft=%s, apply_status=%s, valid=%s, "
+            "in_sync=%s, requires_manual_apply=%s, supports_auto_merge=%s, author_can_auto_merge=%s, "
+            "has_required_approvals=%s, matching_teams=%s",
+            self.id,
+            self.status,
+            self.draft,
+            self.apply_status,
+            self.valid,
+            self.in_sync,
+            self.requires_manual_apply,
+            self.supports_auto_merge,
+            self.author_can_auto_merge,
+            self.has_required_approvals,
+            matching_teams,
+        )
+
         problems = []
         if self.status != PullRequestStatus.OPEN:
-            problems.append("pull request is not open")
+            return [f"pull request is {self.status.value}, only open pull requests can be managed"]
         if self.valid is None:
-            problems.append("pull request has not been checked yet")
+            return ["pull request has not been validated yet, run `/otterdog validate` first"]
         if self.valid is False:
-            problems.append("pull request is not valid")
+            problems.append(
+                "pull request is not valid, check the `/otterdog validate` comment for details and push a fix"
+            )
         if self.supports_auto_merge is None:
-            problems.append("it has not been checked whether the pull request supports auto merge")
+            return ["it has not been checked whether the pull request supports auto merge"]
         if self.supports_auto_merge is False:
             problems.append(
-                "pull request cannot be automatically merged "
+                "pull request cannot be automatically merged  "
                 "(contains secrets, requires web UI changes, includes deletions or touches non-configuration files)"
             )
-
         # If either is true, the pull request can be automerged
         # (author can auto merge without approvals, or it has the required approvals)
         if self.author_can_auto_merge is not True and self.has_required_approvals is not True:
+            from quart import render_template
+
             from otterdog.webapp.utils import describe_admin_teams, describe_approval_teams
 
-            team_description = describe_approval_teams(matching_teams)
-            admin_team_description = describe_admin_teams(self.id.org_id)
+            team_description = await describe_approval_teams(matching_teams, self.id.org_id)
+            admin_team_description = await describe_admin_teams(self.id.org_id)
 
+            # auto-merge requires ONE of these two independent conditions to hold. None does
+            # not mean "still pending / will resolve on its own" - it means the corresponding
+            # event never happened, so say what needs to happen instead of "not checked yet".
             if self.has_required_approvals is None:
-                approval_problem = (
-                    f"it has not been checked yet whether the pull request has been approved by a member of "
-                    f"{team_description}"
+                approval_status = (
+                    f"No approval from a member of `{team_description}` or of `{admin_team_description}` "
+                    "has been submitted yet"
                 )
             else:
-                approval_problem = f"the pull request has not been approved by a member of {team_description}"
+                approval_status = (
+                    f"No approval from a member of `{team_description}` or of `{admin_team_description}` was found"
+                )
 
             if self.author_can_auto_merge is None:
-                author_problem = (
-                    f"it has not been checked yet whether the author is a member of {team_description} or of "
-                    f"{admin_team_description}, which would allow auto-merging without approval"
+                author_status = (
+                    "The author's team membership is unknown "
+                    "(comment `/otterdog team-info` on the pull request to refresh it)"
                 )
             else:
-                author_problem = (
-                    f"the author is not a member of {team_description} or of {admin_team_description}, "
-                    "so cannot auto-merge without such an approval"
-                )
+                author_status = f"The author is not a member of `{team_description}` or of `{admin_team_description}`"
 
-            problems.append(f"{approval_problem}; {author_problem}")
+            problems.append(
+                await render_template(
+                    "comment/automerge_eligibility.txt",
+                    team_description=team_description,
+                    admin_team_description=admin_team_description,
+                    approval_status=approval_status,
+                    author_status=author_status,
+                )
+            )
+
         return problems
 
-    def can_be_automerged(self) -> bool:
-        return not self.automerge_problems()
+    async def can_be_automerged(self) -> bool:
+        return not await self.automerge_problems()
 
 
 class StatisticsModel(Model):

--- a/otterdog/webapp/db/models.py
+++ b/otterdog/webapp/db/models.py
@@ -109,7 +109,14 @@ class PullRequestModel(Model):
     closed_at: datetime | None = None
     merged_at: datetime | None = Field(index=True, default=None)
 
-    def automerge_problems(self) -> list[str]:
+    def automerge_problems(self, matching_teams: list[str] | None = None) -> list[str]:
+        """
+        matching_teams, when passed, is the list of team slugs in the org that were
+        actually resolved (via the GitHub API) to match one of the entries in
+        GITHUB_APPROVAL_TEAMS. Left as None when the caller didn't resolve it (e.g. a
+        plain boolean check), in which case the raw patterns are shown instead of a
+        concrete team name.
+        """
         problems = []
         if self.status != PullRequestStatus.OPEN:
             problems.append("pull request is not open")
@@ -128,26 +135,31 @@ class PullRequestModel(Model):
         # If either is true, the pull request can be automerged
         # (author can auto merge without approvals, or it has the required approvals)
         if self.author_can_auto_merge is not True and self.has_required_approvals is not True:
-            if self.author_can_auto_merge is None and self.has_required_approvals is None:
-                problems.append(
-                    "it has not been checked whether the author can auto merge without approvals, "
-                    "and whether the pull request has the required approvals"
+            from otterdog.webapp.utils import describe_admin_teams, describe_approval_teams
+
+            team_description = describe_approval_teams(matching_teams)
+            admin_team_description = describe_admin_teams(self.id.org_id)
+
+            if self.has_required_approvals is None:
+                approval_problem = (
+                    f"it has not been checked yet whether the pull request has been approved by a member of "
+                    f"{team_description}"
                 )
-            elif self.author_can_auto_merge is None and self.has_required_approvals is False:
-                problems.append(
-                    "pull request does not have the required approvals, "
-                    "and it has not been checked whether the author can auto merge without approvals"
+            else:
+                approval_problem = f"the pull request has not been approved by a member of {team_description}"
+
+            if self.author_can_auto_merge is None:
+                author_problem = (
+                    f"it has not been checked yet whether the author is a member of {team_description} or of "
+                    f"{admin_team_description}, which would allow auto-merging without approval"
                 )
-            elif self.author_can_auto_merge is False and self.has_required_approvals is None:
-                problems.append(
-                    "author is not eligible for merge without approvals, "
-                    "and it has not been checked whether the pull request has the required approvals"
+            else:
+                author_problem = (
+                    f"the author is not a member of {team_description} or of {admin_team_description}, "
+                    "so cannot auto-merge without such an approval"
                 )
-            elif self.author_can_auto_merge is False and self.has_required_approvals is False:
-                problems.append(
-                    "pull request does not have the required approvals, "
-                    "and the author is not eligible for merge without approvals"
-                )
+
+            problems.append(f"{approval_problem}; {author_problem}")
         return problems
 
     def can_be_automerged(self) -> bool:

--- a/otterdog/webapp/db/service.py
+++ b/otterdog/webapp/db/service.py
@@ -142,6 +142,8 @@ async def update_installations_from_config(
                     github_id=github_id,
                     config_repo=org_config.config_repo,
                     base_template=org_config.base_template,
+                    approval_teams=org_config.approval_teams,
+                    admin_teams=org_config.admin_teams,
                 )
 
                 projects_to_update.add(project_name)
@@ -156,6 +158,14 @@ async def update_installations_from_config(
 
                 if model.config_repo != org_config.config_repo:
                     model.config_repo = org_config.config_repo
+                    projects_to_update.add(project_name)
+
+                if model.approval_teams != org_config.approval_teams:
+                    model.approval_teams = org_config.approval_teams
+                    projects_to_update.add(project_name)
+
+                if model.admin_teams != org_config.admin_teams:
+                    model.admin_teams = org_config.admin_teams
                     projects_to_update.add(project_name)
 
             await session.save(model)

--- a/otterdog/webapp/tasks/__init__.py
+++ b/otterdog/webapp/tasks/__init__.py
@@ -277,14 +277,14 @@ async def get_organization_config(
 
 
 def contains_valid_team_for_approval(teams: Iterable[str]) -> bool:
-    # FIXME: teams that can approve must be made configurable, this is just EF specific for now
-    return any(x.endswith("project-leads") for x in teams)
+    from otterdog.webapp.utils import contains_team_matching_approval_pattern
+
+    return contains_team_matching_approval_pattern(teams)
 
 
 def contains_eligible_team_for_auto_merge(teams: Iterable[str]) -> bool:
-    from otterdog.webapp.utils import get_admin_teams
+    from otterdog.webapp.utils import contains_team_matching_approval_pattern, get_admin_teams
 
     admin_teams = get_admin_teams()
 
-    # FIXME: teams that can approve must be made configurable, this is just EF specific for now
-    return any(x.endswith("project-leads") or x in admin_teams for x in teams)
+    return contains_team_matching_approval_pattern(teams) or any(x in admin_teams for x in teams)

--- a/otterdog/webapp/tasks/__init__.py
+++ b/otterdog/webapp/tasks/__init__.py
@@ -276,15 +276,22 @@ async def get_organization_config(
     )
 
 
-def contains_valid_team_for_approval(teams: Iterable[str]) -> bool:
-    from otterdog.webapp.utils import contains_team_matching_approval_pattern
-
-    return contains_team_matching_approval_pattern(teams)
-
-
-def contains_eligible_team_for_auto_merge(teams: Iterable[str]) -> bool:
+async def _contains_approval_or_admin_team(teams: Iterable[str], org_id: str | None = None) -> bool:
     from otterdog.webapp.utils import contains_team_matching_approval_pattern, get_admin_teams
 
-    admin_teams = get_admin_teams()
+    admin_teams = await get_admin_teams(org_id)
 
-    return contains_team_matching_approval_pattern(teams) or any(x in admin_teams for x in teams)
+    return await contains_team_matching_approval_pattern(teams, org_id) or any(x in admin_teams for x in teams)
+
+
+async def contains_valid_team_for_approval(teams: Iterable[str], org_id: str | None = None) -> bool:
+    """A review counts towards the required approvals when it comes from a member of the
+    approval teams, or - same trust extended to authors auto-merging their own pull request -
+    from a member of the admin teams."""
+    return await _contains_approval_or_admin_team(teams, org_id)
+
+
+async def contains_eligible_team_for_auto_merge(teams: Iterable[str], org_id: str | None = None) -> bool:
+    """An author can auto-merge without any approval when they are a member of the approval
+    teams or the admin teams."""
+    return await _contains_approval_or_admin_team(teams, org_id)

--- a/otterdog/webapp/tasks/apply_changes.py
+++ b/otterdog/webapp/tasks/apply_changes.py
@@ -122,7 +122,7 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
 
                 self.logger.error(
                     f"apply for pull request #{self.pull_request_number} triggered by user '{self.author}' "
-                    f"who is not a member of the admin team, skipping"
+                    f"who is not a member of {get_full_admin_team_slugs(self.org_id)}, skipping"
                 )
 
                 return False

--- a/otterdog/webapp/tasks/apply_changes.py
+++ b/otterdog/webapp/tasks/apply_changes.py
@@ -107,7 +107,7 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
 
         if self.author is not None:
             rest_api = await self.rest_api
-            admin_teams = get_admin_teams()
+            admin_teams = await get_admin_teams(self.org_id)
             is_admin = False
             for admin_team in admin_teams:
                 if await rest_api.team.is_user_member_of_team(self.org_id, admin_team, self.author):
@@ -115,14 +115,15 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
                     break
 
             if not is_admin:
+                full_admin_team_slugs = await get_full_admin_team_slugs(self.org_id)
                 comment = await render_template(
-                    "comment/wrong_team_apply_comment.txt", admin_teams=get_full_admin_team_slugs(self.org_id)
+                    "comment/wrong_team_apply_comment.txt", admin_teams=full_admin_team_slugs
                 )
                 await rest_api.issue.create_comment(self.org_id, self.repo_name, str(self.pull_request_number), comment)
 
                 self.logger.error(
                     f"apply for pull request #{self.pull_request_number} triggered by user '{self.author}' "
-                    f"who is not a member of {get_full_admin_team_slugs(self.org_id)}, skipping"
+                    f"who is not a member of {full_admin_team_slugs}, skipping"
                 )
 
                 return False
@@ -227,7 +228,7 @@ class ApplyChangesTask(InstallationBasedTask, Task[ApplyResult]):
                 output=escape_for_github(apply_result.apply_output),
                 success=apply_result.apply_success,
                 partial=apply_result.partial,
-                admin_teams=get_full_admin_team_slugs(self.org_id),
+                admin_teams=await get_full_admin_team_slugs(self.org_id),
             )
 
             await rest_api.issue.create_comment(self.org_id, org_config.config_repo, pull_request_number, result)

--- a/otterdog/webapp/tasks/auto_merge_comment.py
+++ b/otterdog/webapp/tasks/auto_merge_comment.py
@@ -12,6 +12,7 @@ from quart import render_template
 
 from otterdog.webapp.db.models import TaskModel
 from otterdog.webapp.tasks import InstallationBasedTask, Task
+from otterdog.webapp.utils import describe_approval_teams, get_teams_matching_approval_pattern
 
 
 @dataclass(repr=False)
@@ -43,9 +44,16 @@ class AutoMergeCommentTask(InstallationBasedTask, Task[None]):
             self.pull_request_number,
             "<!-- Otterdog Comment: automerge -->",
         ):
-            comment = await render_template("comment/auto_merge_comment.txt")
-
             rest_api = await self.rest_api
+
+            matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
+            team_description = describe_approval_teams(matching_teams)
+
+            comment = await render_template(
+                "comment/auto_merge_comment.txt",
+                team_description=team_description,
+            )
+
             await rest_api.issue.create_comment(
                 self.org_id,
                 self.repo_name,

--- a/otterdog/webapp/tasks/auto_merge_comment.py
+++ b/otterdog/webapp/tasks/auto_merge_comment.py
@@ -47,7 +47,7 @@ class AutoMergeCommentTask(InstallationBasedTask, Task[None]):
             rest_api = await self.rest_api
 
             matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
-            team_description = describe_approval_teams(matching_teams)
+            team_description = await describe_approval_teams(matching_teams, self.org_id)
 
             comment = await render_template(
                 "comment/auto_merge_comment.txt",

--- a/otterdog/webapp/tasks/check_sync.py
+++ b/otterdog/webapp/tasks/check_sync.py
@@ -186,7 +186,7 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
                 comment = await render_template(
                     "comment/out_of_sync_comment.txt",
                     result=escape_for_github(sync_output),
-                    admin_teams=get_full_admin_team_slugs(self.org_id),
+                    admin_teams=await get_full_admin_team_slugs(self.org_id),
                 )
             else:
                 # in case the config is in sync, do not add a redundant comment
@@ -263,7 +263,13 @@ class CheckConfigurationInSyncTask(InstallationBasedTask, Task[bool]):
             in_sync=config_in_sync,
         )
 
-        if pull_request_model.can_be_automerged():
+        if await pull_request_model.can_be_automerged():
+            self.logger.info(
+                "pull request #%d of repo '%s/%s' can be automerged, scheduling automerge task",
+                self.pull_request_number,
+                self.org_id,
+                self.repo_name,
+            )
             self.schedule_automerge_task(self.org_id, self.repo_name, self.pull_request_number)
 
     def __repr__(self) -> str:

--- a/otterdog/webapp/tasks/complete_pull_request.py
+++ b/otterdog/webapp/tasks/complete_pull_request.py
@@ -64,7 +64,7 @@ class CompletePullRequestTask(InstallationBasedTask, Task[None]):
             return False
 
         rest_api = await self.rest_api
-        admin_teams = get_admin_teams()
+        admin_teams = await get_admin_teams(self.org_id)
         is_admin = False
         for admin_team in admin_teams:
             if await rest_api.team.is_user_member_of_team(self.org_id, admin_team, self.author):
@@ -72,14 +72,13 @@ class CompletePullRequestTask(InstallationBasedTask, Task[None]):
                 break
 
         if not is_admin:
-            comment = await render_template(
-                "comment/wrong_team_done_comment.txt", admin_teams=get_full_admin_team_slugs(self.org_id)
-            )
+            full_admin_team_slugs = await get_full_admin_team_slugs(self.org_id)
+            comment = await render_template("comment/wrong_team_done_comment.txt", admin_teams=full_admin_team_slugs)
             await rest_api.issue.create_comment(self.org_id, self.repo_name, str(self.pull_request_number), comment)
 
             self.logger.error(
                 f"apply for pull request #{self.pull_request_number} triggered by user '{self.author}' "
-                f"who is not a member of {get_full_admin_team_slugs(self.org_id)}, skipping"
+                f"who is not a member of {full_admin_team_slugs}, skipping"
             )
 
             return False

--- a/otterdog/webapp/tasks/complete_pull_request.py
+++ b/otterdog/webapp/tasks/complete_pull_request.py
@@ -79,7 +79,7 @@ class CompletePullRequestTask(InstallationBasedTask, Task[None]):
 
             self.logger.error(
                 f"apply for pull request #{self.pull_request_number} triggered by user '{self.author}' "
-                f"who is not a member of the admin team, skipping"
+                f"who is not a member of {get_full_admin_team_slugs(self.org_id)}, skipping"
             )
 
             return False

--- a/otterdog/webapp/tasks/help_comment.py
+++ b/otterdog/webapp/tasks/help_comment.py
@@ -62,12 +62,12 @@ class HelpCommentTask(InstallationBasedTask, Task[None]):
         rest_api = await self.rest_api
 
         matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
-        team_description = describe_approval_teams(matching_teams)
+        team_description = await describe_approval_teams(matching_teams, self.org_id)
 
         comment = await render_template(
             "comment/help_comment.txt",
             team_description=team_description,
-            admin_teams=get_full_admin_team_slugs(self.org_id),
+            admin_teams=await get_full_admin_team_slugs(self.org_id),
         )
 
         await self.minimize_outdated_comments(

--- a/otterdog/webapp/tasks/help_comment.py
+++ b/otterdog/webapp/tasks/help_comment.py
@@ -12,6 +12,11 @@ from quart import render_template
 
 from otterdog.webapp.db.models import TaskModel
 from otterdog.webapp.tasks import InstallationBasedTask, Task
+from otterdog.webapp.utils import (
+    describe_approval_teams,
+    get_full_admin_team_slugs,
+    get_teams_matching_approval_pattern,
+)
 from otterdog.webapp.webhook.github_models import PullRequest
 
 
@@ -55,7 +60,15 @@ class HelpCommentTask(InstallationBasedTask, Task[None]):
         )
 
         rest_api = await self.rest_api
-        comment = await render_template("comment/help_comment.txt")
+
+        matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
+        team_description = describe_approval_teams(matching_teams)
+
+        comment = await render_template(
+            "comment/help_comment.txt",
+            team_description=team_description,
+            admin_teams=get_full_admin_team_slugs(self.org_id),
+        )
 
         await self.minimize_outdated_comments(
             self.org_id,

--- a/otterdog/webapp/tasks/merge_pull_request.py
+++ b/otterdog/webapp/tasks/merge_pull_request.py
@@ -74,8 +74,10 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
             if not contains_eligible_team_for_auto_merge(team_membership):
                 matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
                 return [
-                    f"Only the author of the pull request, a member of {describe_approval_teams(matching_teams)}, "
-                    f"or a member of {describe_admin_teams(self.org_id)} is allowed to auto-merge."
+                    (
+                        f"Only the author of the pull request, a member of {describe_approval_teams(matching_teams)}, "
+                        f"or a member of {describe_admin_teams(self.org_id)} is allowed to auto-merge."
+                    )
                 ]
 
         return []

--- a/otterdog/webapp/tasks/merge_pull_request.py
+++ b/otterdog/webapp/tasks/merge_pull_request.py
@@ -17,6 +17,11 @@ from otterdog.webapp.tasks import (
     Task,
     contains_eligible_team_for_auto_merge,
 )
+from otterdog.webapp.utils import (
+    describe_admin_teams,
+    describe_approval_teams,
+    get_teams_matching_approval_pattern,
+)
 from otterdog.webapp.webhook.github_models import PullRequest
 
 
@@ -45,10 +50,14 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
         else:
             self._pr_model = pr_model
 
-        if problems := pr_model.automerge_problems():
-            return problems
-
         rest_api = await self.rest_api
+
+        if pr_model.automerge_problems():
+            matching_teams = None
+            if pr_model.author_can_auto_merge is not True and pr_model.has_required_approvals is not True:
+                matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
+            return pr_model.automerge_problems(matching_teams=matching_teams)
+
         response = await rest_api.pull_request.get_pull_request(
             self.org_id, self.repo_name, str(self.pull_request_number)
         )
@@ -63,11 +72,10 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
             team_membership = [team["name"] for team in team_data]
 
             if not contains_eligible_team_for_auto_merge(team_membership):
+                matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
                 return [
-                    (
-                        "Only the author of the pull request, a project-lead or a member of the admin teams "
-                        "is allowed to auto-merge."
-                    )
+                    f"Only the author of the pull request, a member of {describe_approval_teams(matching_teams)}, "
+                    f"or a member of {describe_admin_teams(self.org_id)} is allowed to auto-merge."
                 ]
 
         return []

--- a/otterdog/webapp/tasks/merge_pull_request.py
+++ b/otterdog/webapp/tasks/merge_pull_request.py
@@ -52,11 +52,11 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
 
         rest_api = await self.rest_api
 
-        if pr_model.automerge_problems():
+        if await pr_model.automerge_problems():
             matching_teams = None
             if pr_model.author_can_auto_merge is not True and pr_model.has_required_approvals is not True:
                 matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
-            return pr_model.automerge_problems(matching_teams=matching_teams)
+            return await pr_model.automerge_problems(matching_teams=matching_teams)
 
         response = await rest_api.pull_request.get_pull_request(
             self.org_id, self.repo_name, str(self.pull_request_number)
@@ -71,12 +71,14 @@ class MergePullRequestTask(InstallationBasedTask, Task[None]):
             team_data = await graphql_api.get_team_membership(self.org_id, self.author)
             team_membership = [team["name"] for team in team_data]
 
-            if not contains_eligible_team_for_auto_merge(team_membership):
+            if not await contains_eligible_team_for_auto_merge(team_membership, self.org_id):
                 matching_teams = await get_teams_matching_approval_pattern(rest_api, self.org_id)
+                team_description = await describe_approval_teams(matching_teams, self.org_id)
+                admin_team_description = await describe_admin_teams(self.org_id)
                 return [
                     (
-                        f"Only the author of the pull request, a member of {describe_approval_teams(matching_teams)}, "
-                        f"or a member of {describe_admin_teams(self.org_id)} is allowed to auto-merge."
+                        f"Only the author of the pull request, a member of {team_description}, "
+                        f"or a member of {admin_team_description} is allowed to auto-merge."
                     )
                 ]
 

--- a/otterdog/webapp/tasks/retrieve_team_membership.py
+++ b/otterdog/webapp/tasks/retrieve_team_membership.py
@@ -86,7 +86,7 @@ class RetrieveTeamMembershipTask(InstallationBasedTask, Task[None]):
             team_data = await graphql_api.get_team_membership(self.org_id, user)
             team_membership = [team["name"] for team in team_data]
             teams = [(team, f"https://github.com/orgs/{self.org_id}/teams/{team}") for team in team_membership]
-            author_can_auto_merge = contains_eligible_team_for_auto_merge(team_membership)
+            author_can_auto_merge = await contains_eligible_team_for_auto_merge(team_membership, self.org_id)
         else:
             teams = []
             author_can_auto_merge = False

--- a/otterdog/webapp/tasks/update_pull_request.py
+++ b/otterdog/webapp/tasks/update_pull_request.py
@@ -67,7 +67,7 @@ class UpdatePullRequestTask(InstallationBasedTask, Task[None]):
 
             self.logger.debug(f"approved by teams: {approved_by_teams}")
 
-            has_required_approvals = contains_valid_team_for_approval(approved_by_teams)
+            has_required_approvals = await contains_valid_team_for_approval(approved_by_teams, self.org_id)
 
             pull_request_model = await update_or_create_pull_request(
                 self.org_id,
@@ -76,7 +76,13 @@ class UpdatePullRequestTask(InstallationBasedTask, Task[None]):
                 has_required_approvals=has_required_approvals,
             )
 
-            if pull_request_model.can_be_automerged():
+            if await pull_request_model.can_be_automerged():
+                self.logger.info(
+                    "pull request #%d of repo '%s/%s' can be automerged, scheduling automerge task",
+                    self.pull_request_number,
+                    self.org_id,
+                    self.repo_name,
+                )
                 self.schedule_automerge_task(self.org_id, self.repo_name, self.pull_request_number)
         else:
             await update_or_create_pull_request(

--- a/otterdog/webapp/tasks/validate_pull_request.py
+++ b/otterdog/webapp/tasks/validate_pull_request.py
@@ -197,7 +197,7 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
                 sha=self._pull_request.head.sha,
                 result=escape_for_github(validation_result.plan_output),
                 warnings=warnings,
-                admin_teams=get_full_admin_team_slugs(self.org_id),
+                admin_teams=await get_full_admin_team_slugs(self.org_id),
             )
 
             await self.minimize_outdated_comments(
@@ -272,7 +272,13 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
             ),
         )
 
-        if pull_request_model.can_be_automerged():
+        if await pull_request_model.can_be_automerged():
+            self.logger.info(
+                "pull request #%d of repo '%s/%s' can be automerged, scheduling automerge task",
+                self.pull_request_number,
+                self.org_id,
+                self.repo_name,
+            )
             self.schedule_automerge_task(self.org_id, self.repo_name, self.pull_request_number)
 
     async def _get_pull_request_files(self, rest_api: RestApi) -> list[str]:

--- a/otterdog/webapp/templates/comment/auto_merge_comment.txt
+++ b/otterdog/webapp/templates/comment/auto_merge_comment.txt
@@ -2,7 +2,7 @@
 This Pull Request is eligible for auto-merging as it passed the following checks:
 
 - valid configuration
-- approved by a project lead
+- approved by a member of {{ team_description }}
 - does not require any secrets
 - does not update settings only accessible via the GitHub Web UI
 - does not remove any resource

--- a/otterdog/webapp/templates/comment/automerge_eligibility.txt
+++ b/otterdog/webapp/templates/comment/automerge_eligibility.txt
@@ -1,0 +1,13 @@
+`/otterdog merge` requires **one** of the following conditions:
+
+- The pull request author is a member of `{{ team_description }}` or `{{ admin_team_description }}`
+- A member of one of these teams has approved the pull request.
+
+### Current status
+
+- {{ author_status }}
+- {{ approval_status }}
+
+### How to proceed
+
+Ask a member of `{{ team_description }}` to review and approve this pull request (or, failing that, a member of `{{ admin_team_description }}`), then run `/otterdog merge` again.

--- a/otterdog/webapp/templates/comment/automerge_problems.txt
+++ b/otterdog/webapp/templates/comment/automerge_problems.txt
@@ -2,5 +2,5 @@
 > This pull request cannot be auto-merged via `/otterdog merge`
 
 {% for problem in problems %}
-- {{ problem }}
+{{ problem }}
 {% endfor %}

--- a/otterdog/webapp/templates/comment/help_comment.txt
+++ b/otterdog/webapp/templates/comment/help_comment.txt
@@ -5,7 +5,7 @@ You can manually add reviewers to this PR to eventually enable auto-merging.
 The following conditions need to be fulfilled for auto-merging to be available:
 
 - valid configuration
-- approved by a project lead
+- approved by a member of {{ team_description }}
 - does not require any secrets
 - does not update settings only accessible via the GitHub Web UI
 - does not remove any resource
@@ -20,6 +20,6 @@ You can trigger otterdog actions by commenting on this PR:
 - `/otterdog validate info` validates the configuration change, printing also validation infos
 - `/otterdog check-sync` checks if the base ref is in sync with live settings
 - `/otterdog merge` merges and applies the changes if the PR is eligible for auto-merging (only accessible for the author)
-- `/otterdog done` notifies the self-service bot that a required manual apply operation has been performed (only accessible for members of the admin team)
-- `/otterdog apply` re-apply a previously failed attempt (only accessible for members of the admin team)
+- `/otterdog done` notifies the self-service bot that a required manual apply operation has been performed (only accessible for members of the admin team(s) `{{ admin_teams|join(', ') }}`)
+- `/otterdog apply` re-apply a previously failed attempt (only accessible for members of the admin team(s) `{{ admin_teams|join(', ') }}`)
 </details>

--- a/otterdog/webapp/utils.py
+++ b/otterdog/webapp/utils.py
@@ -330,7 +330,13 @@ def get_approval_team_patterns() -> list[str]:
 
 
 def team_matches_approval_pattern(team: str) -> bool:
-    return any(re.search(pattern, team) is not None for pattern in get_approval_team_patterns())
+    for pattern in get_approval_team_patterns():
+        try:
+            if re.search(pattern, team) is not None:
+                return True
+        except re.error as e:
+            logger.warning("invalid regex in GITHUB_APPROVAL_TEAMS entry '%s': %s", pattern, e)
+    return False
 
 
 def contains_team_matching_approval_pattern(teams: Iterable[str]) -> bool:

--- a/otterdog/webapp/utils.py
+++ b/otterdog/webapp/utils.py
@@ -320,6 +320,55 @@ def get_full_admin_team_slugs(org_id: str) -> list[str]:
     return [f"{org_id}/{team_slug}" for team_slug in get_admin_teams()]
 
 
+def describe_admin_teams(org_id: str) -> str:
+    return "team " + " or ".join(f"'{team}'" for team in get_full_admin_team_slugs(org_id))
+
+
+def get_approval_team_patterns() -> list[str]:
+    patterns = str(current_app.config["GITHUB_APPROVAL_TEAMS"])
+    return [pattern.strip() for pattern in patterns.split(",") if pattern.strip()]
+
+
+def team_matches_approval_pattern(team: str) -> bool:
+    return any(re.search(pattern, team) is not None for pattern in get_approval_team_patterns())
+
+
+def contains_team_matching_approval_pattern(teams: Iterable[str]) -> bool:
+    return any(team_matches_approval_pattern(team) for team in teams)
+
+
+async def get_teams_matching_approval_pattern(rest_api: RestApi, org_id: str) -> list[str]:
+    team_slugs = await rest_api.team.get_team_slugs(org_id)
+    return [team_slug for team_slug in team_slugs if team_matches_approval_pattern(team_slug)]
+
+
+def _describe_approval_team_patterns() -> str:
+    patterns = get_approval_team_patterns()
+    if len(patterns) == 1:
+        return f"pattern '{patterns[0]}'"
+    else:
+        return "patterns " + " or ".join(f"'{pattern}'" for pattern in patterns)
+
+
+def describe_approval_teams(matching_teams: list[str] | None) -> str:
+    """
+    matching_teams is the list of team slugs in the org resolved (via the GitHub API) to
+    match one of the entries in GITHUB_APPROVAL_TEAMS (each entry is a regex, matched via
+    re.search, so a plain team slug also works as an entry). Pass None when it wasn't
+    resolved (falls back to showing the raw patterns), or an empty list when resolved but
+    nothing matched.
+    """
+    if matching_teams is None:
+        return f"a team matching {_describe_approval_team_patterns()}"
+    elif matching_teams:
+        return "team " + " or ".join(f"'{team}'" for team in matching_teams)
+    else:
+        return (
+            f"a team matching {_describe_approval_team_patterns()} "
+            "(no team in this organization currently matches any of these patterns)"
+        )
+
+
 async def fetch_config_from_github(
     rest_api: RestApi,
     org_id: str,

--- a/otterdog/webapp/utils.py
+++ b/otterdog/webapp/utils.py
@@ -312,27 +312,62 @@ async def _load_global_blueprints(ref: str | None = None) -> list[Blueprint]:
     return list(blueprints.values())
 
 
-def get_admin_teams() -> list[str]:
-    teams = str(current_app.config["GITHUB_ADMIN_TEAMS"])
-    return teams.split(",")
+async def get_admin_teams(org_id: str | None = None) -> list[str]:
+    """
+    Resolves the comma-separated GITHUB_ADMIN_TEAMS for org_id. An org can override
+    the global GITHUB_ADMIN_TEAMS setting via the "admin_teams" key in its otterdog
+    config entry, synced into InstallationModel.admin_teams. Falls back to the global
+    setting when org_id is None, the org has no installation, or no override is set.
+    """
+    teams_config: str | None = None
+
+    if org_id is not None:
+        from otterdog.webapp.db.service import get_installation_by_github_id
+
+        installation = await get_installation_by_github_id(org_id)
+        if installation is not None and installation.admin_teams:
+            teams_config = installation.admin_teams
+
+    if teams_config is None:
+        teams_config = str(current_app.config["GITHUB_ADMIN_TEAMS"])
+
+    return teams_config.split(",")
 
 
-def get_full_admin_team_slugs(org_id: str) -> list[str]:
-    return [f"{org_id}/{team_slug}" for team_slug in get_admin_teams()]
+async def get_full_admin_team_slugs(org_id: str) -> list[str]:
+    return [f"{org_id}/{team_slug}" for team_slug in await get_admin_teams(org_id)]
 
 
-def describe_admin_teams(org_id: str) -> str:
-    teams = [f"{org_id}/{team_slug.strip()}" for team_slug in get_admin_teams() if team_slug.strip()]
+async def describe_admin_teams(org_id: str) -> str:
+    teams = [f"{org_id}/{team_slug.strip()}" for team_slug in await get_admin_teams(org_id) if team_slug.strip()]
     return "team " + " or ".join(f"'{team}'" for team in teams)
 
 
-def get_approval_team_patterns() -> list[str]:
-    patterns = str(current_app.config["GITHUB_APPROVAL_TEAMS"])
-    return [pattern.strip() for pattern in patterns.split(",") if pattern.strip()]
+async def get_approval_team_patterns(org_id: str | None = None) -> list[str]:
+    """
+    Resolves the comma-separated GITHUB_APPROVAL_TEAMS patterns for org_id.
+    An org can override the global GITHUB_APPROVAL_TEAMS setting via the
+    "approval_teams" key in its otterdog config entry, synced into
+    InstallationModel.approval_teams. Falls back to the global setting when
+    org_id is None, the org has no installation, or no override is set.
+    """
+    patterns_config: str | None = None
+
+    if org_id is not None:
+        from otterdog.webapp.db.service import get_installation_by_github_id
+
+        installation = await get_installation_by_github_id(org_id)
+        if installation is not None and installation.approval_teams:
+            patterns_config = installation.approval_teams
+
+    if patterns_config is None:
+        patterns_config = str(current_app.config["GITHUB_APPROVAL_TEAMS"])
+
+    return [pattern.strip() for pattern in patterns_config.split(",") if pattern.strip()]
 
 
-def team_matches_approval_pattern(team: str) -> bool:
-    for pattern in get_approval_team_patterns():
+def _team_matches_patterns(team: str, patterns: list[str]) -> bool:
+    for pattern in patterns:
         try:
             if re.search(pattern, team) is not None:
                 return True
@@ -341,41 +376,49 @@ def team_matches_approval_pattern(team: str) -> bool:
     return False
 
 
-def contains_team_matching_approval_pattern(teams: Iterable[str]) -> bool:
-    return any(team_matches_approval_pattern(team) for team in teams)
+async def team_matches_approval_pattern(team: str, org_id: str | None = None) -> bool:
+    patterns = await get_approval_team_patterns(org_id)
+    return _team_matches_patterns(team, patterns)
+
+
+async def contains_team_matching_approval_pattern(teams: Iterable[str], org_id: str | None = None) -> bool:
+    patterns = await get_approval_team_patterns(org_id)
+    return any(_team_matches_patterns(team, patterns) for team in teams)
 
 
 async def get_teams_matching_approval_pattern(rest_api: RestApi, org_id: str) -> list[str]:
+    patterns = await get_approval_team_patterns(org_id)
     team_slugs = await rest_api.team.get_team_slugs(org_id)
-    return [team_slug for team_slug in team_slugs if team_matches_approval_pattern(team_slug)]
+    return [team_slug for team_slug in team_slugs if _team_matches_patterns(team_slug, patterns)]
 
 
-def _describe_approval_team_patterns() -> str:
-    patterns = get_approval_team_patterns()
+def _describe_approval_team_patterns(patterns: list[str]) -> str:
     if len(patterns) == 1:
         return f"pattern '{patterns[0]}'"
     else:
         return "patterns " + " or ".join(f"'{pattern}'" for pattern in patterns)
 
 
-def describe_approval_teams(matching_teams: list[str] | None) -> str:
+async def describe_approval_teams(matching_teams: list[str] | None, org_id: str | None = None) -> str:
     """
     matching_teams is the list of team slugs in the org resolved (via the GitHub API) to
     match one of the entries in GITHUB_APPROVAL_TEAMS (each entry is a regex, matched via
     re.search, so a plain team slug also works as an entry). Pass None when it wasn't
     resolved (falls back to showing the raw patterns), or an empty list when resolved but
-    nothing matched.
+    nothing matched. org_id resolves the org's GITHUB_APPROVAL_TEAMS override, if any.
     """
-    if not get_approval_team_patterns():
+    patterns = await get_approval_team_patterns(org_id)
+
+    if not patterns:
         return "no approval teams are configured (GITHUB_APPROVAL_TEAMS is empty)"
 
     if matching_teams is None:
-        return f"a team matching {_describe_approval_team_patterns()}"
+        return f"a team matching {_describe_approval_team_patterns(patterns)}"
     elif matching_teams:
         return "team " + " or ".join(f"'{team}'" for team in matching_teams)
     else:
         return (
-            f"a team matching {_describe_approval_team_patterns()} "
+            f"a team matching {_describe_approval_team_patterns(patterns)} "
             "(no team in this organization currently matches any of these patterns)"
         )
 

--- a/otterdog/webapp/utils.py
+++ b/otterdog/webapp/utils.py
@@ -364,6 +364,9 @@ def describe_approval_teams(matching_teams: list[str] | None) -> str:
     resolved (falls back to showing the raw patterns), or an empty list when resolved but
     nothing matched.
     """
+    if not get_approval_team_patterns():
+        return "no approval teams are configured (GITHUB_APPROVAL_TEAMS is empty)"
+
     if matching_teams is None:
         return f"a team matching {_describe_approval_team_patterns()}"
     elif matching_teams:

--- a/otterdog/webapp/utils.py
+++ b/otterdog/webapp/utils.py
@@ -9,6 +9,7 @@
 import asyncio
 import json
 import re
+from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 from functools import cache
 from logging import getLogger

--- a/otterdog/webapp/utils.py
+++ b/otterdog/webapp/utils.py
@@ -321,7 +321,8 @@ def get_full_admin_team_slugs(org_id: str) -> list[str]:
 
 
 def describe_admin_teams(org_id: str) -> str:
-    return "team " + " or ".join(f"'{team}'" for team in get_full_admin_team_slugs(org_id))
+    teams = [f"{org_id}/{team_slug.strip()}" for team_slug in get_admin_teams() if team_slug.strip()]
+    return "team " + " or ".join(f"'{team}'" for team in teams)
 
 
 def get_approval_team_patterns() -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from otterdog.models.repository import Repository
 from tests.models import ModelTest
 
 
-@pytest.fixture()
+@pytest.fixture
 def repository_test():
     class RepositoryTest(ModelTest):
         def create_model(self, data: Mapping[str, Any]) -> ModelObject:
@@ -34,7 +34,7 @@ def repository_test():
     return RepositoryTest()
 
 
-@pytest.fixture()
+@pytest.fixture
 def deterministic_days_since():
     fixed_now = datetime(2025, 1, 1, tzinfo=UTC)
 
@@ -88,7 +88,7 @@ class MockGitHubProvider:
         return self
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_github_provider():
     """Fixture that provides a configurable mock GitHub provider.
 

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -22,6 +22,7 @@ os.environ.setdefault("OTTERDOG_CONFIG_OWNER", "dummy-owner")
 os.environ.setdefault("OTTERDOG_CONFIG_REPO", "dummy-repo")
 os.environ.setdefault("OTTERDOG_CONFIG_PATH", "dummy-path")
 os.environ.setdefault("OTTERDOG_CONFIG_TOKEN", "dummy-config-token")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "dummy-webhook-secret")
 
 from otterdog.webapp import create_app
 

--- a/tests/webapp/conftest.py
+++ b/tests/webapp/conftest.py
@@ -27,7 +27,7 @@ os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "dummy-webhook-secret")
 from otterdog.webapp import create_app
 
 
-@pytest.fixture()
+@pytest.fixture
 def app():
     from otterdog.webapp.config import TestingConfig
 

--- a/tests/webapp/test_utils.py
+++ b/tests/webapp/test_utils.py
@@ -8,7 +8,14 @@
 
 from datetime import timedelta
 
-from otterdog.webapp.utils import backoff_if_needed, current_utc_time
+from otterdog.webapp.utils import (
+    backoff_if_needed,
+    contains_team_matching_approval_pattern,
+    current_utc_time,
+    describe_approval_teams,
+    get_approval_team_patterns,
+    team_matches_approval_pattern,
+)
 
 
 async def test_backoff_if_needed():
@@ -23,3 +30,50 @@ async def test_backoff_if_needed():
     await backoff_if_needed(start - timedelta(seconds=60), timedelta(seconds=3))
     end = current_utc_time()
     assert end - start < timedelta(seconds=1)
+
+
+async def test_get_approval_team_patterns_splits_and_strips_entries(app):
+    async with app.app_context():
+        app.config["GITHUB_APPROVAL_TEAMS"] = " project-leads , .*-committers$ "
+        assert get_approval_team_patterns() == ["project-leads", ".*-committers$"]
+
+        app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$"
+        assert get_approval_team_patterns() == ["project-leads$"]
+
+
+async def test_team_matches_approval_pattern_with_literal_and_regex_entries(app):
+    async with app.app_context():
+        app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads,.*-committers$"
+
+        assert team_matches_approval_pattern("org/project-leads") is True
+        assert team_matches_approval_pattern("org/example-committers") is True
+        assert team_matches_approval_pattern("org/some-other-team") is False
+
+
+async def test_contains_team_matching_approval_pattern(app):
+    async with app.app_context():
+        app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$"
+
+        assert contains_team_matching_approval_pattern(["org/some-team", "org/project-leads"]) is True
+        assert contains_team_matching_approval_pattern(["org/some-team", "org/other-team"]) is False
+        assert contains_team_matching_approval_pattern([]) is False
+
+
+async def test_describe_approval_teams(app):
+    async with app.app_context():
+        app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$"
+
+        assert describe_approval_teams(None) == "a team matching pattern 'project-leads$'"
+        assert describe_approval_teams(["org/project-leads"]) == "team 'org/project-leads'"
+        assert describe_approval_teams(["org/team-a", "org/team-b"]) == "team 'org/team-a' or 'org/team-b'"
+        assert describe_approval_teams([]) == (
+            "a team matching pattern 'project-leads$' "
+            "(no team in this organization currently matches any of these patterns)"
+        )
+
+
+async def test_describe_approval_teams_with_multiple_patterns(app):
+    async with app.app_context():
+        app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$,.*-committers$"
+
+        assert describe_approval_teams(None) == "a team matching patterns 'project-leads$' or '.*-committers$'"

--- a/tests/webapp/test_utils.py
+++ b/tests/webapp/test_utils.py
@@ -49,6 +49,10 @@ async def test_team_matches_approval_pattern_with_literal_and_regex_entries(app)
         assert team_matches_approval_pattern("org/example-committers") is True
         assert team_matches_approval_pattern("org/some-other-team") is False
 
+        # Invalid regex entries should be ignored (and must not crash matching)
+        app.config["GITHUB_APPROVAL_TEAMS"] = "(,project-leads$"
+        assert team_matches_approval_pattern("org/project-leads") is True
+
 
 async def test_contains_team_matching_approval_pattern(app):
     async with app.app_context():

--- a/tests/webapp/test_utils.py
+++ b/tests/webapp/test_utils.py
@@ -7,6 +7,7 @@
 #  *******************************************************************************
 
 from datetime import timedelta
+from unittest.mock import AsyncMock, patch
 
 from otterdog.webapp.utils import (
     backoff_if_needed,
@@ -35,42 +36,70 @@ async def test_backoff_if_needed():
 async def test_get_approval_team_patterns_splits_and_strips_entries(app):
     async with app.app_context():
         app.config["GITHUB_APPROVAL_TEAMS"] = " project-leads , .*-committers$ "
-        assert get_approval_team_patterns() == ["project-leads", ".*-committers$"]
+        assert await get_approval_team_patterns() == ["project-leads", ".*-committers$"]
 
         app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$"
-        assert get_approval_team_patterns() == ["project-leads$"]
+        assert await get_approval_team_patterns() == ["project-leads$"]
+
+
+def _installation_with_approval_teams(approval_teams: str | None):
+    installation = AsyncMock()
+    installation.approval_teams = approval_teams
+    return installation
+
+
+async def test_get_approval_team_patterns_org_override(app):
+    async with app.app_context():
+        app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$"
+
+        with patch(
+            "otterdog.webapp.db.service.get_installation_by_github_id",
+            return_value=_installation_with_approval_teams("org-leads,.*-maintainers$"),
+        ):
+            assert await get_approval_team_patterns("SomeOrg") == ["org-leads", ".*-maintainers$"]
+
+        # no installation found for the org: falls back to the global setting
+        with patch("otterdog.webapp.db.service.get_installation_by_github_id", return_value=None):
+            assert await get_approval_team_patterns("SomeOrg") == ["project-leads$"]
+
+        # installation found but without an override: falls back to the global setting
+        with patch(
+            "otterdog.webapp.db.service.get_installation_by_github_id",
+            return_value=_installation_with_approval_teams(None),
+        ):
+            assert await get_approval_team_patterns("SomeOrg") == ["project-leads$"]
 
 
 async def test_team_matches_approval_pattern_with_literal_and_regex_entries(app):
     async with app.app_context():
         app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads,.*-committers$"
 
-        assert team_matches_approval_pattern("org/project-leads") is True
-        assert team_matches_approval_pattern("org/example-committers") is True
-        assert team_matches_approval_pattern("org/some-other-team") is False
+        assert await team_matches_approval_pattern("org/project-leads") is True
+        assert await team_matches_approval_pattern("org/example-committers") is True
+        assert await team_matches_approval_pattern("org/some-other-team") is False
 
         # Invalid regex entries should be ignored (and must not crash matching)
         app.config["GITHUB_APPROVAL_TEAMS"] = "(,project-leads$"
-        assert team_matches_approval_pattern("org/project-leads") is True
+        assert await team_matches_approval_pattern("org/project-leads") is True
 
 
 async def test_contains_team_matching_approval_pattern(app):
     async with app.app_context():
         app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$"
 
-        assert contains_team_matching_approval_pattern(["org/some-team", "org/project-leads"]) is True
-        assert contains_team_matching_approval_pattern(["org/some-team", "org/other-team"]) is False
-        assert contains_team_matching_approval_pattern([]) is False
+        assert await contains_team_matching_approval_pattern(["org/some-team", "org/project-leads"]) is True
+        assert await contains_team_matching_approval_pattern(["org/some-team", "org/other-team"]) is False
+        assert await contains_team_matching_approval_pattern([]) is False
 
 
 async def test_describe_approval_teams(app):
     async with app.app_context():
         app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$"
 
-        assert describe_approval_teams(None) == "a team matching pattern 'project-leads$'"
-        assert describe_approval_teams(["org/project-leads"]) == "team 'org/project-leads'"
-        assert describe_approval_teams(["org/team-a", "org/team-b"]) == "team 'org/team-a' or 'org/team-b'"
-        assert describe_approval_teams([]) == (
+        assert await describe_approval_teams(None) == "a team matching pattern 'project-leads$'"
+        assert await describe_approval_teams(["org/project-leads"]) == "team 'org/project-leads'"
+        assert await describe_approval_teams(["org/team-a", "org/team-b"]) == "team 'org/team-a' or 'org/team-b'"
+        assert await describe_approval_teams([]) == (
             "a team matching pattern 'project-leads$' "
             "(no team in this organization currently matches any of these patterns)"
         )
@@ -80,4 +109,4 @@ async def test_describe_approval_teams_with_multiple_patterns(app):
     async with app.app_context():
         app.config["GITHUB_APPROVAL_TEAMS"] = "project-leads$,.*-committers$"
 
-        assert describe_approval_teams(None) == "a team matching patterns 'project-leads$' or '.*-committers$'"
+        assert await describe_approval_teams(None) == "a team matching patterns 'project-leads$' or '.*-committers$'"


### PR DESCRIPTION
Team based auto-merge approval was hardcoded to a single `project-leads` suffix match.

This PR replaces that hardcoding with a configurable `GITHUB_APPROVAL_TEAMS` setting, and makes user messages
reflect the actual configured teams instead of generic text.

It supports list and regex.

<img width="717" height="190" alt="image" src="https://github.com/user-attachments/assets/12116699-cf88-4fca-9038-2d0232e07e66" />
 