### PR TITLE
Pin dependency-track chart to 1.3.0 for scaffold

### DIFF
--- a/dev/skaffold.yaml
+++ b/dev/skaffold.yaml
@@ -69,6 +69,7 @@ profiles:
           - &dependency-track-release
             name: dependency-track
             remoteChart: dependency-track/dependency-track
+            version: 1.3.0
             namespace: otterdog
             createNamespace: true
             valuesFiles:


### PR DESCRIPTION
The latest version of the dependencytrack Helm chart is not compatible with the current skaffold configuration.

[dependencytrack chart 1.3.0](https://github.com/DependencyTrack/helm-charts/releases/tag/dependency-track-1.3.0) supports dependencytrack 4.14.3, while newer chart versions have upgraded to dependencytrack 5.