### PR TITLE
ngrok as a tailscale alternative for dev tunnel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ site
 
 ### Ignoring development values for helm charts
 values.yaml
+dev/.dev-values-ngrok-host.yaml
 
 ### Ignoring otterdog out directory orgs and conf
 orgs/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init test check clean build-image init-minikube dev-webapp dev-webapp-ts dev-webapp-tunnel dev-webapp-tunnel-local clean-ingress-finalizers clean-tailscale-proxies clean-webapp docs docs-serve help
+.PHONY: init test check clean build-image init-minikube dev-webapp dev-webapp-ts dev-webapp-tunnel dev-webapp-tunnel-local dev-webapp-ngrok dev-webapp-ngrok-local clean-ingress-finalizers clean-tailscale-proxies clean-webapp docs docs-serve help
 
 PIPX := $(shell command -v pipx --version 2> /dev/null)
 POETRY := $(shell command -v poetry 2> /dev/null)
@@ -94,6 +94,14 @@ dev-webapp-tunnel: init-minikube clean-ingress-finalizers clean-tailscale-proxie
 dev-webapp-tunnel-local: init-minikube clean-ingress-finalizers clean-tailscale-proxies  ## Run full stack development (includes webapp)
 	eval $$(minikube -p minikube docker-env)
 	skaffold dev --filename=dev/skaffold.yaml --profile dev-tunnel-local --cleanup=false
+
+dev-webapp-ngrok: init-minikube clean-ingress-finalizers  ## Run full stack development (includes webapp), exposed via ngrok
+	eval $$(minikube -p minikube docker-env)
+	skaffold dev --filename=dev/skaffold.yaml --profile dev-ngrok --cleanup=false
+
+dev-webapp-ngrok-local: init-minikube clean-ingress-finalizers  ## Run full stack development (includes webapp), exposed via ngrok, using local Helm chart checkout
+	eval $$(minikube -p minikube docker-env)
+	skaffold dev --filename=dev/skaffold.yaml --profile dev-ngrok-local --cleanup=false
 
 check:  ## Run all pre-commit checks
 	poetry run prek -a

--- a/dev/dev-values-ngrok.yaml
+++ b/dev/dev-values-ngrok.yaml
@@ -1,0 +1,6 @@
+ingress:
+  enabled: true
+  className: ngrok
+  ingressClassName: ngrok
+  defaultBackend:
+    enabled: true

--- a/dev/skaffold.yaml
+++ b/dev/skaffold.yaml
@@ -115,3 +115,71 @@ profiles:
             createNamespace: true
             valuesFiles: *tunnel-valuesFiles
             setValueTemplates: *otterdog-tunnel-setValues
+
+
+  # Local development with ngrok (alternative to tailscale).
+  # Required env vars: NGROK_API_KEY, NGROK_AUTHTOKEN, NGROK_DOMAIN
+  # NGROK_DOMAIN must be the exact reserved domain (e.g. a free otterdog-<hash>.ngrok-free.dev
+  # domain, or a custom domain you own): free ngrok domains do NOT support subdomains, so no
+  # "otterdog." prefix is added. Dependency Track is not exposed via ngrok; use
+  # `kubectl port-forward` to reach it (see docs/developing_otterdog/testing.md).
+  - name: dev-ngrok
+    deploy:
+      helm:
+        hooks: &ngrok-hooks
+          before:
+            - host:
+                command: ["sh", "-c", "if [ ! -f ./values.yaml ]; then echo 'Error: Please create the `./values.yaml`'; exit 1; fi"]
+            - host:
+                command: ["sh", "-c", "if [ -z \"$NGROK_API_KEY\" ]; then echo 'Error: NGROK_API_KEY is not set'; exit 1; fi"]
+            - host:
+                command: ["sh", "-c", "if [ -z \"$NGROK_AUTHTOKEN\" ]; then echo 'Error: NGROK_AUTHTOKEN is not set'; exit 1; fi"]
+            - host:
+                command: ["sh", "-c", "if [ -z \"$NGROK_DOMAIN\" ]; then echo 'Error: NGROK_DOMAIN is not set'; exit 1; fi"]
+            # Helm's `--set` replaces whole lists instead of merging them, so setting only
+            # ingress.hosts[0].host via setValueTemplates silently drops the chart's default
+            # ingress.hosts[0].paths (see https://helm.sh/docs/chart_template_guide/values_files/).
+            # Generate a small values file with host+paths together instead.
+            - host:
+                command: ["sh", "-c", "echo \"ingress: {hosts: [{host: $NGROK_DOMAIN, paths: [{path: /, pathType: ImplementationSpecific}]}]}\" > ./dev/.dev-values-ngrok-host.yaml"]
+          after:
+              - host:
+                  command: ["sh", "-c", "while ! kubectl rollout status deployment/otterdog -n otterdog --timeout=10s 2>/dev/null; do sleep 10; done && until kubectl exec -n otterdog deploy/otterdog -- /app/init-webapp localhost 5000; do sleep 2; done && echo \"Otterdog is reachable at: https://$NGROK_DOMAIN\""]
+        releases:
+          - &dependency-track-ngrok-release
+            name: dependency-track
+            remoteChart: dependency-track/dependency-track
+            version: 1.3.0
+            namespace: otterdog
+            createNamespace: true
+          - &ngrok-release
+            name: otterdog-ngrok-operator
+            remoteChart: ngrok/ngrok-operator
+            namespace: ngrok
+            createNamespace: true
+            setValueTemplates:
+              credentials.apiKey: "{{.NGROK_API_KEY}}"
+              credentials.authtoken: "{{.NGROK_AUTHTOKEN}}"
+          - name: otterdog
+            remoteChart: eclipse-csi/otterdog
+            namespace: otterdog
+            createNamespace: true
+            valuesFiles: &ngrok-valuesFiles
+              - ./dev/dev-values.yaml
+              - ./dev/dev-values-ngrok.yaml
+              - ./values.yaml
+              - ./dev/.dev-values-ngrok-host.yaml
+
+  # Same as "dev-ngrok" but uses the local Helm chart checkout for the otterdog release.
+  - name: dev-ngrok-local
+    deploy:
+      helm:
+        hooks: *ngrok-hooks
+        releases:
+          - *dependency-track-ngrok-release
+          - *ngrok-release
+          - name: otterdog
+            chartPath: ../helm-charts/charts/otterdog
+            namespace: otterdog
+            createNamespace: true
+            valuesFiles: *ngrok-valuesFiles

--- a/docs/developing_otterdog/testing.md
+++ b/docs/developing_otterdog/testing.md
@@ -5,7 +5,7 @@ This document describes how to run tests for Otterdog. You should set up your de
 ## Prerequisites
 
 * [Skaffold](https://skaffold.dev/docs/install/)
-* [tailscale](https://tailscale.com/download)
+* [tailscale](https://tailscale.com/download) or [ngrok](https://ngrok.com/download) (either can expose the dev environment for GitHub Webhooks, see below)
 * [minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Flinux%2Fx86-64%2Fstable%2Fbinary+download)
 * [k9s](https://k9scli.io/topics/install/)
 
@@ -119,7 +119,10 @@ helm repo add eclipse-csi https://eclipse-csi.github.io/helm-charts
 make dev-webapp
 ```
 
-If you want use the integration with GitHub, you can use the tailscale
+If you want use the integration with GitHub, you can use tailscale or ngrok to expose your development environment. Pick one:
+
+* [Setup a tailscale tunnel](#setup-a-tailscale-to-enable-github-webhooks-to-your-development-environment)
+* [Setup an ngrok tunnel](#setup-ngrok-to-enable-github-webhooks-to-your-development-environment) (alternative to tailscale)
 
 #### Setup a tailscale to enable GitHub Webhooks to your development environment
 
@@ -212,7 +215,7 @@ HTTPS Certificates -> Click `Enable HTTPS...`
 
 **NOTES**:
 
- - Replace `<OTTERDOG-WEBAPP>` by your `tail<some hash>.ts.net`
+ - Replace `<OTTERDOG-WEBAPP>` by your `tail<some hash>.ts.net` (tailscale) or `otterdog.<your reserved domain>` (ngrok)
  - You can always double check the URL at https://login.tailscale.com/admin/machines as multiple instances
  of your development environment can generate `otterdog-1`, `otterdog-2` ...
 
@@ -311,6 +314,66 @@ curl https://otterdog.tail<some hash>.ts.net/internal/init
 
 Dependency Track is reachable at `https://sbom.tail<some hash>.ts.net` (it still needs to be configured — see below)
 
+#### Setup ngrok to enable GitHub Webhooks to your development environment
+
+Alternative to the tailscale tunnel above.
+
+1. Sign up/Login to [ngrok](https://ngrok.com)
+
+2. Go to the [ngrok dashboard](https://dashboard.ngrok.com)
+
+We use the [ngrok Kubernetes Operator](https://ngrok.com/docs/k8s/) (minikube), configuring it:
+
+1. Get your API Key from https://dashboard.ngrok.com/api and your Authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
+
+2. Reserve a domain in https://dashboard.ngrok.com/domains
+
+    > **NOTE:** Free ngrok domains (e.g. `<something>.ngrok-free.dev`/`.ngrok-free.app`) do not support subdomains — only a custom domain you own, with wildcard DNS delegated to ngrok on a paid plan, does (see [ngrok custom domains](https://ngrok.com/docs/universal-gateway/domains/)). `NGROK_DOMAIN` below is therefore used as-is (no `otterdog.` prefix) for the Otterdog webapp. Dependency Track is not exposed via ngrok in this dev setup — access it with `kubectl port-forward` instead (see [Optional] Configure dependency track below).
+
+3. Export them in your terminal
+
+    ```bash
+    export NGROK_API_KEY=<api key>
+    export NGROK_AUTHTOKEN=<authtoken>
+    export NGROK_DOMAIN=<your reserved domain>
+    ```
+
+    > **NOTE:** If you close the terminal, you will need to re-export these values.
+
+#### Run otterdog with ngrok
+
+Alternative to `#### Run otterdog with tailscale` above.
+
+Make sure you have the `eclipse-csi`, `ngrok`, and `dependency-track` Helm chart repositories added:
+
+```bash
+helm repo add dependency-track https://dependencytrack.github.io/helm-charts
+helm repo add eclipse-csi https://eclipse-csi.github.io/helm-charts
+helm repo add ngrok https://charts.ngrok.com
+```
+
+Start the otterdog webapp with the ngrok tunnel:
+
+```bash
+make dev-webapp-ngrok
+```
+
+The Otterdog WebApp is reachable at `https://<your reserved domain>`
+
+Trigger the Otterdog initialization:
+
+```bash
+curl https://<your reserved domain>/internal/init
+```
+
+Dependency Track is not exposed via ngrok; reach it with:
+
+```bash
+kubectl port-forward -n otterdog svc/dependency-track-frontend 8080:8080
+```
+
+then open `http://localhost:8080` (it still needs to be configured — see below)
+
 #### Verify webhook delivery
 
 Once the service is running and the GitHub App is installed in your organization, verify that webhooks are correctly reaching the backend by sending a **ping** event from the app's advanced settings:
@@ -325,7 +388,7 @@ Click **Redeliver** on the most recent **ping** delivery to trigger a test event
 
 #### [Optional] Configure dependency track
 
-1. Access the https://sbom.tail<some hash>.ts.net ([default DependencyTrack credentials](https://docs.dependencytrack.org/getting-started/initial-startup/))
+1. Access `https://sbom.tail<some hash>.ts.net` (tailscale) or `http://localhost:8080` via `kubectl port-forward` (ngrok, see above) — [default DependencyTrack credentials](https://docs.dependencytrack.org/getting-started/initial-startup/)
    (First time will ask to change password and re-login)
 
 2. To generate the `dependencyTrackToken`, go to `Administration` > `Access Management` > `Teams`


### PR DESCRIPTION
Tailscale is only usable on their trial plan without a paid subscription. This adds ngrok as a free alternative using the ngrok-operator Kubernetes operator.

Limitations: 
* Free ngrok domains don't support subdomains, so NGROK_DOMAIN is used as-is for the otterdog webapp (no otterdog. prefix, unlike the tailscale profile).
* Dependency Track is not exposed via ngrok in this setup (would need a second reserved domain on the free tier). Only reachable locally with kubectl port-forward.
