### PR TITLE
feat: max_cache_size_gb

### DIFF
--- a/docs/reference/organization/repository/index.md
+++ b/docs/reference/organization/repository/index.md
@@ -61,6 +61,7 @@ Definition of a Repository for a GitHub organization, the following properties a
 | Key                                        | Value        | Description                                                        | Notes                                                                                             |
 |--------------------------------------------|--------------|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | _enabled_                                  | boolean      | If GitHub actions are enabled for this repository                  |                                                                                                   |
+| _max_cache_size_gb_                        | integer      | Maximum total size of all GitHub Actions caches, in GB             |                                                                                                   |
 | _allowed_actions_                          | string       | Defines which type of GitHub Actions are permitted to run          | `all`, `local_only` or `selected`                                                                 |
 | _allow_github_owned_actions_               | boolean      | If GitHub owned actions are permitted to run                       | Only taken into account when `allowed_actions` is set to `selected`                               |
 | _allow_verified_creator_actions_           | boolean      | If GitHub Actions from verified creators are permitted to run      | Only taken into account when `allowed_actions` is set to `selected`                               |
@@ -69,6 +70,8 @@ Definition of a Repository for a GitHub organization, the following properties a
 | _actions_can_approve_pull_request_reviews_ | boolean      | If actions can approve and merge pull requests                     |                                                                                                   |
 | _fork_pr_approval_policy_                  | string       | Controls when fork PR workflows require approval from a maintainer | `first_time_contributors_new_to_github`, `first_time_contributors` or `all_external_contributors` |
 
+Increasing the cache size limit may incur costs.
+Changes to the limit are flagged for designated review and are not eligible for automatic merging.
 
 ## Jsonnet Function
 
@@ -135,6 +138,7 @@ Definition of a Repository for a GitHub organization, the following properties a
           web_commit_signoff_required: false,
           workflows+: {
             enabled: false,
+            max_cache_size_gb: 50,
           },
           branch_protection_rules: [
             orgs.newBranchProtectionRule('main'),

--- a/docs/reference/organization/settings.md
+++ b/docs/reference/organization/settings.md
@@ -53,6 +53,10 @@ The following table captures all supported settings on organization level:
 | _default_workflow_permissions_             | string       | The default workflow permissions granted to the GITHUB_TOKEN       | `read` or `write`                                                                                 |
 | _actions_can_approve_pull_request_reviews_ | boolean      | If actions can approve and merge pull requests                     |                                                                                                   |
 | _fork_pr_approval_policy_                  | string       | Controls when fork PR workflows require approval from a maintainer | `first_time_contributors_new_to_github`, `first_time_contributors` or `all_external_contributors` |
+| _max_cache_size_gb_                         | integer      | Maximum total size of all GitHub Actions caches for each repository, in GB |                                                                                                  |
+
+Increasing the cache size limit may incur costs.
+Changes to the limit are flagged for designated review and are not eligible for automatic merging.
 
 ## Validation rules
 

--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -75,6 +75,9 @@ local newRepo(name) = {
   workflows: {
     enabled: true,
 
+    # Maximum total size of all GitHub Actions caches for this repository, in GB.
+    max_cache_size_gb: 10,
+
     # allow all actions by default
     allowed_actions: "all",
     allow_github_owned_actions: true,
@@ -391,6 +394,9 @@ local newOrg(name, id=name) = {
       # enable workflows for all repositories
       enabled_repositories: "all",
       selected_repositories: [],
+
+      # Maximum total size of all GitHub Actions caches for each repository, in GB.
+      max_cache_size_gb: 10,
 
       # allow all actions by default
       allowed_actions: "all",

--- a/otterdog/models/__init__.py
+++ b/otterdog/models/__init__.py
@@ -159,6 +159,22 @@ class LivePatch(Generic[MT]):
             case LivePatchType.CHANGE:
                 return unwrap(self.expected_object).contains_secrets()
 
+    def is_cost_related(self) -> bool:
+        """Return whether applying this patch can increase managed costs.
+
+        Deletions cannot introduce new spending, so only additions and changes
+        inspect the desired object or its changed values.
+        """
+        match self.patch_type:
+            case LivePatchType.ADD:
+                return unwrap(self.expected_object).is_cost_related()
+
+            case LivePatchType.REMOVE:
+                return False
+
+            case LivePatchType.CHANGE:
+                return unwrap(self.expected_object).changes_are_cost_related(unwrap(self.changes))
+
     async def apply(self, org_id: str, provider: GitHubProvider) -> None:
         await self.fn(self, org_id, provider)
 
@@ -290,6 +306,14 @@ class EmbeddedModelObject(_DefaultValuesMixin, ABC):
 
     def include_field_for_patch_computation(self, field: dataclasses.Field) -> bool:
         return self.include_field_for_diff_computation(field)
+
+    def is_cost_related(self) -> bool:
+        """Return whether this embedded model contains cost-affecting settings."""
+        return False
+
+    def changes_are_cost_related(self, changes: dict[str, Change]) -> bool:
+        """Return whether a change to this embedded model can affect costs."""
+        return False
 
     def keys(
         self,
@@ -601,6 +625,25 @@ class ModelObject(_DefaultValuesMixin, ABC):
 
     def include_field_for_patch_computation(self, field: dataclasses.Field) -> bool:
         return self.include_field_for_diff_computation(field)
+
+    def is_cost_related(self) -> bool:
+        """Propagate cost metadata from nested models to their owning object."""
+        for field in self.all_fields():
+            value = self.__getattribute__(field.name)
+            if isinstance(value, (EmbeddedModelObject, ModelObject)) and value.is_cost_related():
+                return True
+
+        return False
+
+    def changes_are_cost_related(self, changes: dict[str, Change]) -> bool:
+        """Propagate cost metadata through nested change dictionaries."""
+        for key, change in changes.items():
+            value = self.__getattribute__(key)
+            if isinstance(value, (EmbeddedModelObject, ModelObject)) and isinstance(change.to_value, dict):
+                if value.changes_are_cost_related(change.to_value):
+                    return True
+
+        return False
 
     def include_for_live_patch(self, context: LivePatchContext) -> bool:
         """

--- a/otterdog/models/workflow_settings.py
+++ b/otterdog/models/workflow_settings.py
@@ -17,6 +17,7 @@ from jsonbender import OptionalS, S  # type: ignore
 from otterdog.models import EmbeddedModelObject, FailureType, PatchContext, ValidationContext
 from otterdog.utils import (
     UNSET,
+    Change,
     IndentingPrinter,
     is_set_and_valid,
     write_patch_object_as_json,
@@ -56,6 +57,15 @@ class WorkflowSettings(EmbeddedModelObject, abc.ABC):
     in https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28
     """
 
+    max_cache_size_gb: int
+    """
+    ``max_cache_size_gb`` controls the maximum total GitHub Actions cache size
+    for the relevant repository or organization.
+
+    Cache-size changes are marked as cost-related so pull-request validation can
+    require designated review and prevent automatic merging.
+    """
+
     _selected_action_properties: ClassVar[list[str]] = [
         "allow_github_owned_actions",
         "allow_verified_creator_actions",
@@ -67,6 +77,18 @@ class WorkflowSettings(EmbeddedModelObject, abc.ABC):
         "selected": 2,
         "local_only": 3,
     }
+
+    # Keep billing-affecting settings centralized so both full-object and
+    # change-level cost checks use the same definition.
+    _cost_related_properties: ClassVar[set[str]] = {"max_cache_size_gb"}
+
+    def is_cost_related(self) -> bool:
+        """Return whether this settings object contains a cost-affecting value."""
+        return any(is_set_and_valid(self.__getattribute__(key)) for key in self._cost_related_properties)
+
+    def changes_are_cost_related(self, changes: dict[str, Change]) -> bool:
+        """Return whether the supplied settings changes can affect costs."""
+        return any(key in changes for key in self._cost_related_properties)
 
     @classmethod
     def get_allowed_actions_level(cls, allowed_actions: str) -> int:

--- a/otterdog/providers/github/rest/org_client.py
+++ b/otterdog/providers/github/rest/org_client.py
@@ -516,6 +516,7 @@ class OrgClient(RestClient):
             workflow_settings.update(await self._get_default_workflow_permissions(org_id))
 
         workflow_settings.update(await self._get_fork_pr_approval_policy(org_id))
+        workflow_settings.update(await self._get_max_cache_size_gb(org_id))
 
         return workflow_settings
 
@@ -551,7 +552,37 @@ class OrgClient(RestClient):
         if "approval_policy" in data:
             await self._update_fork_pr_approval_policy(org_id, {"approval_policy": data["approval_policy"]})
 
+        if "max_cache_size_gb" in data:
+            await self._update_max_cache_size_gb(org_id, data["max_cache_size_gb"])
+
         _logger.debug("updated %d workflow setting(s)", len(data))
+
+    async def _get_max_cache_size_gb(self, org_id: str) -> dict[str, Any]:
+        _logger.debug("retrieving cache size for org '%s'", org_id)
+
+        response = await self.requester.request_json("GET", f"/organizations/{org_id}/actions/cache/storage-limit")
+        if "max_cache_size_gb" not in response:
+            # An incomplete success response must not become an absent setting:
+            # reconciliation would then skip drift detection for the configured limit.
+            raise RuntimeError(
+                f"GitHub response for organization cache size of '{org_id}' does not contain 'max_cache_size_gb'"
+            )
+
+        return {"max_cache_size_gb": response["max_cache_size_gb"]}
+
+    async def _update_max_cache_size_gb(self, org_id: str, max_cache_size_gb: int) -> None:
+        _logger.debug("updating cache size for org '%s'", org_id)
+
+        status, body = await self.requester.request_raw(
+            "PUT",
+            f"/organizations/{org_id}/actions/cache/storage-limit",
+            data=json.dumps({"max_cache_size_gb": max_cache_size_gb}),
+        )
+
+        if status != 204:
+            raise RuntimeError(f"failed to update cache size for org '{org_id}': {body}")
+
+        _logger.debug("updated cache size for org '%s'", org_id)
 
     async def _get_selected_repositories_for_workflow_settings(self, org_id: str) -> list[dict[str, Any]]:
         _logger.debug("retrieving selected repositories for org workflow settings of org '%s'", org_id)

--- a/otterdog/providers/github/rest/repo_client.py
+++ b/otterdog/providers/github/rest/repo_client.py
@@ -1156,6 +1156,8 @@ class RepoClient(RestClient):
         if not is_private:
             workflow_settings.update(await self._get_fork_pr_approval_policy(org_id, repo_name))
 
+        workflow_settings.update(await self._get_max_cache_size_gb(org_id, repo_name))
+
         return workflow_settings
 
     async def update_workflow_settings(
@@ -1193,7 +1195,38 @@ class RepoClient(RestClient):
         if not is_private and "approval_policy" in data:
             await self._update_fork_pr_approval_policy(org_id, repo_name, {"approval_policy": data["approval_policy"]})
 
+        if "max_cache_size_gb" in data:
+            await self._update_max_cache_size_gb(org_id, repo_name, data["max_cache_size_gb"])
+
         _logger.debug("updated %d workflow setting(s)", len(data))
+
+    async def _get_max_cache_size_gb(self, org_id: str, repo_name: str) -> dict[str, Any]:
+        _logger.debug("retrieving cache size for repo '%s/%s'", org_id, repo_name)
+
+        response = await self.requester.request_json("GET", f"/repos/{org_id}/{repo_name}/actions/cache/storage-limit")
+        if "max_cache_size_gb" not in response:
+            # An incomplete success response must not become an absent setting:
+            # reconciliation would then skip drift detection for the configured limit.
+            raise RuntimeError(
+                f"GitHub response for repository cache size of '{org_id}/{repo_name}' "
+                "does not contain 'max_cache_size_gb'"
+            )
+
+        return {"max_cache_size_gb": response["max_cache_size_gb"]}
+
+    async def _update_max_cache_size_gb(self, org_id: str, repo_name: str, max_cache_size_gb: int) -> None:
+        _logger.debug("updating cache size for repo '%s/%s'", org_id, repo_name)
+
+        status, body = await self.requester.request_raw(
+            "PUT",
+            f"/repos/{org_id}/{repo_name}/actions/cache/storage-limit",
+            data=json.dumps({"max_cache_size_gb": max_cache_size_gb}),
+        )
+
+        if status != 204:
+            raise RuntimeError(f"failed to update cache size for repo '{org_id}/{repo_name}': {body}")
+
+        _logger.debug("updated cache size for repo '%s/%s'", org_id, repo_name)
 
     async def _get_selected_actions_for_workflow_settings(self, org_id: str, repo_name: str) -> dict[str, Any]:
         _logger.debug("retrieving allowed actions for repo '%s/%s'", org_id, repo_name)

--- a/otterdog/resources/schemas/workflow-settings.json
+++ b/otterdog/resources/schemas/workflow-settings.json
@@ -12,6 +12,7 @@
     },
     "default_workflow_permissions": { "type": "string" },
     "actions_can_approve_pull_request_reviews": { "type": "boolean" },
-    "fork_pr_approval_policy": { "type": "string" }
+    "fork_pr_approval_policy": { "type": "string" },
+    "max_cache_size_gb": { "type": "integer" }
   }
 }

--- a/otterdog/webapp/tasks/validate_pull_request.py
+++ b/otterdog/webapp/tasks/validate_pull_request.py
@@ -37,11 +37,18 @@ if TYPE_CHECKING:
 
 @dataclass
 class ValidationResult:
+    """Validation output and safety gates for applying a pull request.
+
+    Cost-related changes are tracked separately because they require designated
+    review and must not be auto-merged, even when they need no manual UI work.
+    """
+
     plan_output: str = ""
     validation_success: bool = False
     touches_non_configuration: bool = False
     requires_secrets: bool | None = None
     requires_web_ui: bool | None = None
+    cost_related: bool | None = None
     includes_deletions: bool | None = None
 
 
@@ -156,6 +163,7 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
                 ):
                     validation_result.requires_secrets = any(x.requires_secrets() for x in patches)
                     validation_result.requires_web_ui = any(x.requires_web_ui() for x in patches)
+                    validation_result.cost_related = any(x.is_cost_related() for x in patches)
 
                     validation_result.includes_deletions = any(x.patch_type == LivePatchType.REMOVE for x in patches)
 
@@ -191,6 +199,9 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
                 warnings.append(
                     "some of requested changes require accessing the Web UI, need to apply these changes manually"
                 )
+            if validation_result.cost_related:
+                # Cost changes need review even when the change itself is API-applicable.
+                warnings.append("some of requested changes may incur costs, need review by the designated team")
 
             comment = await render_template(
                 "comment/validation_comment.txt",
@@ -263,10 +274,12 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
             self.repo_name,
             self._pull_request,
             valid=validation_result.validation_success,
-            requires_manual_apply=validation_result.requires_secrets or validation_result.requires_web_ui,
+            requires_manual_apply=(validation_result.requires_secrets or validation_result.requires_web_ui),
             supports_auto_merge=not (
                 validation_result.requires_secrets
                 or validation_result.requires_web_ui
+                # Cost-affecting changes require explicit review before merging.
+                or validation_result.cost_related
                 or validation_result.includes_deletions
                 or validation_result.touches_non_configuration
             ),

--- a/tests/models/test_workflow_settings.py
+++ b/tests/models/test_workflow_settings.py
@@ -10,7 +10,7 @@ import pytest
 from pretend import stub
 
 from otterdog.models.workflow_settings import WorkflowSettings
-from otterdog.utils import UNSET
+from otterdog.utils import UNSET, Change
 
 
 # Subclass to test abstract WorkflowSettings logic.
@@ -29,6 +29,7 @@ def workflow_settings():
         default_workflow_permissions="read",
         actions_can_approve_pull_request_reviews=True,
         fork_pr_approval_policy="first_time_contributors",
+        max_cache_size_gb=10,
     )
 
 
@@ -86,3 +87,7 @@ class TestWorkflowSettingsMapping:
         data = {}
         mapping = await TestWorkflowSettings.get_mapping_to_provider("test-id", data, provider)
         assert "approval_policy" not in mapping
+
+    def test_cache_size_changes_are_cost_related(self, workflow_settings):
+        assert workflow_settings.is_cost_related()
+        assert workflow_settings.changes_are_cost_related({"max_cache_size_gb": Change(10, 50)})

--- a/tests/providers/github/integration/test_workflow_settings.py
+++ b/tests/providers/github/integration/test_workflow_settings.py
@@ -1,0 +1,174 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+import pytest
+
+from otterdog.models.organization_workflow_settings import OrganizationWorkflowSettings
+from otterdog.models.repo_workflow_settings import RepositoryWorkflowSettings
+from otterdog.providers.github.exception import GitHubException
+
+from .conftest import GitHubProviderTestKit
+
+# Constants
+ORG_ID = "test-org"
+REPO_NAME = "test-repo"
+
+
+async def test_read_org_workflow_settings(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions",
+        response_json={"enabled_repositories": "none", "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions/fork-pr-contributor-approval",
+        response_json={"approval_policy": "first_time_contributors"},
+    )
+    github.http.expect(
+        "GET",
+        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        response_json={"max_cache_size_gb": 50},
+    )
+
+    provider_data = await github.provider.get_org_workflow_settings(ORG_ID)
+    settings = OrganizationWorkflowSettings.from_provider_data(ORG_ID, provider_data)
+
+    assert settings.max_cache_size_gb == 50
+
+
+@pytest.mark.parametrize("response_status", [403, 500])
+async def test_read_org_workflow_settings_propagates_cache_limit_errors(
+    github: GitHubProviderTestKit, response_status: int
+):
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions",
+        response_json={"enabled_repositories": "none", "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions/fork-pr-contributor-approval",
+        response_json={"approval_policy": "first_time_contributors"},
+    )
+    github.http.expect(
+        "GET",
+        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        response_status=response_status,
+        response_text="cache limit unavailable",
+    )
+
+    with pytest.raises(GitHubException):
+        await github.provider.get_org_workflow_settings(ORG_ID)
+
+
+async def test_read_org_workflow_settings_rejects_incomplete_cache_limit_response(
+    github: GitHubProviderTestKit,
+):
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions",
+        response_json={"enabled_repositories": "none", "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions/fork-pr-contributor-approval",
+        response_json={"approval_policy": "first_time_contributors"},
+    )
+    github.http.expect(
+        "GET",
+        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        response_json={},
+    )
+
+    with pytest.raises(RuntimeError, match="max_cache_size_gb"):
+        await github.provider.get_org_workflow_settings(ORG_ID)
+
+
+async def test_update_org_workflow_settings(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        request_json={"max_cache_size_gb": 50},
+        response_status=204,
+    )
+
+    provider_data = await OrganizationWorkflowSettings.dict_to_provider_data(
+        ORG_ID, {"max_cache_size_gb": 50}, github.provider
+    )
+    await github.provider.update_org_workflow_settings(ORG_ID, provider_data)
+
+
+async def test_read_repo_workflow_settings(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/permissions",
+        response_json={"enabled": False, "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        response_json={"max_cache_size_gb": 50},
+    )
+
+    provider_data = await github.provider.get_repo_workflow_settings(ORG_ID, REPO_NAME, is_private=True)
+    settings = RepositoryWorkflowSettings.from_provider_data(ORG_ID, provider_data)
+
+    assert settings.max_cache_size_gb == 50
+
+
+@pytest.mark.parametrize("response_status", [403, 500])
+async def test_read_repo_workflow_settings_propagates_cache_limit_errors(
+    github: GitHubProviderTestKit, response_status: int
+):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/permissions",
+        response_json={"enabled": False, "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        response_status=response_status,
+        response_text="cache limit unavailable",
+    )
+
+    with pytest.raises(GitHubException):
+        await github.provider.get_repo_workflow_settings(ORG_ID, REPO_NAME, is_private=True)
+
+
+async def test_read_repo_workflow_settings_rejects_incomplete_cache_limit_response(
+    github: GitHubProviderTestKit,
+):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/permissions",
+        response_json={"enabled": False, "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        response_json={},
+    )
+
+    with pytest.raises(RuntimeError, match="max_cache_size_gb"):
+        await github.provider.get_repo_workflow_settings(ORG_ID, REPO_NAME, is_private=True)
+
+
+async def test_update_repo_workflow_settings(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        request_json={"max_cache_size_gb": 50},
+        response_status=204,
+    )
+
+    provider_data = await RepositoryWorkflowSettings.dict_to_provider_data(
+        ORG_ID, {"max_cache_size_gb": 50}, github.provider
+    )
+    await github.provider.update_repo_workflow_settings(ORG_ID, REPO_NAME, provider_data, is_private=True)

--- a/tests/providers/github/rest/test_org_client.py
+++ b/tests/providers/github/rest/test_org_client.py
@@ -11,7 +11,8 @@ import json
 import pretend
 import pytest
 
-from otterdog.providers.github.rest.org_client import GitHubException, OrgClient
+from otterdog.providers.github.exception import GitHubException
+from otterdog.providers.github.rest.org_client import OrgClient
 
 
 class TestOrgClientForkPrApprovalPolicy:
@@ -113,6 +114,11 @@ class TestOrgClientForkPrApprovalPolicy:
         mock_restapi = pretend.stub(requester=mock_requester)
         org_client = OrgClient(mock_restapi)
         org_client._get_fork_pr_approval_policy = mock_get
+
+        async def mock_cache_size(org):
+            return {"max_cache_size_gb": 10}
+
+        org_client._get_max_cache_size_gb = mock_cache_size
 
         result = await org_client.get_workflow_settings("org")
 

--- a/tests/providers/github/rest/test_repo_client.py
+++ b/tests/providers/github/rest/test_repo_client.py
@@ -3,7 +3,8 @@ import json
 import pretend
 import pytest
 
-from otterdog.providers.github.rest.repo_client import GitHubException, RepoClient
+from otterdog.providers.github.exception import GitHubException
+from otterdog.providers.github.rest.repo_client import RepoClient
 
 
 class TestRepoClientCodeScanningConfig:
@@ -244,6 +245,11 @@ class TestRepoClientForkPrApprovalPolicy:
         repo_client = RepoClient(mock_restapi)
         repo_client._get_fork_pr_approval_policy = mock_get
 
+        async def mock_cache_size(org, repo):
+            return {"max_cache_size_gb": 10}
+
+        repo_client._get_max_cache_size_gb = mock_cache_size
+
         result = await repo_client.get_workflow_settings("org", "repo")
 
         # Assert result includes the approval policy
@@ -263,6 +269,11 @@ class TestRepoClientForkPrApprovalPolicy:
         mock_restapi = pretend.stub(requester=mock_requester)
         repo_client = RepoClient(mock_restapi)
         repo_client._get_fork_pr_approval_policy = mock_get
+
+        async def mock_cache_size(org, repo):
+            return {"max_cache_size_gb": 10}
+
+        repo_client._get_max_cache_size_gb = mock_cache_size
 
         result = await repo_client.get_workflow_settings("org", "repo", is_private=True)
 

--- a/tests/schemas/test_workflow_settings_schema.py
+++ b/tests/schemas/test_workflow_settings_schema.py
@@ -83,6 +83,7 @@ class TestWorkflowSettingsSchemaComposition:
             "default_workflow_permissions": "read",
             "actions_can_approve_pull_request_reviews": True,
             "fork_pr_approval_policy": "first_time_contributors",
+            "max_cache_size_gb": 50,
         }
 
         validator.validate(data)
@@ -117,6 +118,7 @@ class TestWorkflowSettingsSchemaComposition:
             "default_workflow_permissions": "write",
             "actions_can_approve_pull_request_reviews": False,
             "fork_pr_approval_policy": "all_external_contributors",
+            "max_cache_size_gb": 50,
         }
 
         validator.validate(data)
@@ -136,6 +138,7 @@ class TestWorkflowSettingsSchemaComposition:
             "default_workflow_permissions": "read",
             "actions_can_approve_pull_request_reviews": False,
             "fork_pr_approval_policy": "first_time_contributors_new_to_github",
+            "max_cache_size_gb": 50,
         }
 
         validator.validate(data)
@@ -165,6 +168,7 @@ class TestWorkflowSettingsSchemaComposition:
             ("default_workflow_permissions", "write"),
             ("actions_can_approve_pull_request_reviews", True),
             ("fork_pr_approval_policy", "first_time_contributors"),
+            ("max_cache_size_gb", 50),
         ],
     )
     def test_org_workflow_inherits_individual_base_fields(
@@ -190,6 +194,7 @@ class TestWorkflowSettingsSchemaComposition:
             ("default_workflow_permissions", "read"),
             ("actions_can_approve_pull_request_reviews", False),
             ("fork_pr_approval_policy", "all_external_contributors"),
+            ("max_cache_size_gb", 50),
         ],
     )
     def test_repo_workflow_inherits_individual_base_fields(


### PR DESCRIPTION
I need to configure `max_cache_size_gb` for an internal setup. I'm just guessing how you would like to have it within eclipse: I've added `cost_related` flag which disables `supports_auto_merge`.

Note that this does indeed add quite some API calls. There is no better API like bulk or graphql available. That's the cost of adding features :-( Ideally most of the calls will be cached.