### PR TITLE
Support GitHub Actions cache storage limits

### DIFF
--- a/docs/reference/organization/repository/index.md
+++ b/docs/reference/organization/repository/index.md
@@ -61,6 +61,7 @@ Definition of a Repository for a GitHub organization, the following properties a
 | Key                                        | Value        | Description                                                        | Notes                                                                                             |
 |--------------------------------------------|--------------|--------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | _enabled_                                  | boolean      | If GitHub actions are enabled for this repository                  |                                                                                                   |
+| _max_cache_size_gb_                        | integer      | Maximum total size of all GitHub Actions caches, in GB             |                                                                                                   |
 | _allowed_actions_                          | string       | Defines which type of GitHub Actions are permitted to run          | `all`, `local_only` or `selected`                                                                 |
 | _allow_github_owned_actions_               | boolean      | If GitHub owned actions are permitted to run                       | Only taken into account when `allowed_actions` is set to `selected`                               |
 | _allow_verified_creator_actions_           | boolean      | If GitHub Actions from verified creators are permitted to run      | Only taken into account when `allowed_actions` is set to `selected`                               |
@@ -69,6 +70,8 @@ Definition of a Repository for a GitHub organization, the following properties a
 | _actions_can_approve_pull_request_reviews_ | boolean      | If actions can approve and merge pull requests                     |                                                                                                   |
 | _fork_pr_approval_policy_                  | string       | Controls when fork PR workflows require approval from a maintainer | `first_time_contributors_new_to_github`, `first_time_contributors` or `all_external_contributors` |
 
+Increasing the cache size limit may incur costs.
+Changes to the limit are flagged for designated review and are not eligible for automatic merging.
 
 ## Jsonnet Function
 
@@ -135,6 +138,7 @@ Definition of a Repository for a GitHub organization, the following properties a
           web_commit_signoff_required: false,
           workflows+: {
             enabled: false,
+            max_cache_size_gb: 50,
           },
           branch_protection_rules: [
             orgs.newBranchProtectionRule('main'),

--- a/docs/reference/organization/settings.md
+++ b/docs/reference/organization/settings.md
@@ -53,6 +53,10 @@ The following table captures all supported settings on organization level:
 | _default_workflow_permissions_             | string       | The default workflow permissions granted to the GITHUB_TOKEN       | `read` or `write`                                                                                 |
 | _actions_can_approve_pull_request_reviews_ | boolean      | If actions can approve and merge pull requests                     |                                                                                                   |
 | _fork_pr_approval_policy_                  | string       | Controls when fork PR workflows require approval from a maintainer | `first_time_contributors_new_to_github`, `first_time_contributors` or `all_external_contributors` |
+| _max_cache_size_gb_                         | integer      | Maximum total size of all GitHub Actions caches for each repository, in GB |                                                                                                  |
+
+Increasing the cache size limit may incur costs.
+Changes to the limit are flagged for designated review and are not eligible for automatic merging.
 
 ## Validation rules
 

--- a/examples/template/otterdog-defaults.libsonnet
+++ b/examples/template/otterdog-defaults.libsonnet
@@ -75,6 +75,9 @@ local newRepo(name) = {
   workflows: {
     enabled: true,
 
+    # Maximum total size of all GitHub Actions caches for this repository, in GB.
+    max_cache_size_gb: 10,
+
     # allow all actions by default
     allowed_actions: "all",
     allow_github_owned_actions: true,
@@ -391,6 +394,9 @@ local newOrg(name, id=name) = {
       # enable workflows for all repositories
       enabled_repositories: "all",
       selected_repositories: [],
+
+      # Maximum total size of all GitHub Actions caches for each repository, in GB.
+      max_cache_size_gb: 10,
 
       # allow all actions by default
       allowed_actions: "all",

--- a/otterdog/models/__init__.py
+++ b/otterdog/models/__init__.py
@@ -159,6 +159,22 @@ class LivePatch(Generic[MT]):
             case LivePatchType.CHANGE:
                 return unwrap(self.expected_object).contains_secrets()
 
+    def is_cost_related(self) -> bool:
+        """Return whether applying this patch can increase managed costs.
+
+        Deletions cannot introduce new spending, so only additions and changes
+        inspect the desired object or its changed values.
+        """
+        match self.patch_type:
+            case LivePatchType.ADD:
+                return unwrap(self.expected_object).is_cost_related()
+
+            case LivePatchType.REMOVE:
+                return False
+
+            case LivePatchType.CHANGE:
+                return unwrap(self.expected_object).changes_are_cost_related(unwrap(self.changes))
+
     async def apply(self, org_id: str, provider: GitHubProvider) -> None:
         await self.fn(self, org_id, provider)
 
@@ -290,6 +306,14 @@ class EmbeddedModelObject(_DefaultValuesMixin, ABC):
 
     def include_field_for_patch_computation(self, field: dataclasses.Field) -> bool:
         return self.include_field_for_diff_computation(field)
+
+    def is_cost_related(self) -> bool:
+        """Return whether this embedded model contains cost-affecting settings."""
+        return False
+
+    def changes_are_cost_related(self, changes: dict[str, Change]) -> bool:
+        """Return whether a change to this embedded model can affect costs."""
+        return False
 
     def keys(
         self,
@@ -601,6 +625,25 @@ class ModelObject(_DefaultValuesMixin, ABC):
 
     def include_field_for_patch_computation(self, field: dataclasses.Field) -> bool:
         return self.include_field_for_diff_computation(field)
+
+    def is_cost_related(self) -> bool:
+        """Propagate cost metadata from nested models to their owning object."""
+        for field in self.all_fields():
+            value = self.__getattribute__(field.name)
+            if isinstance(value, (EmbeddedModelObject, ModelObject)) and value.is_cost_related():
+                return True
+
+        return False
+
+    def changes_are_cost_related(self, changes: dict[str, Change]) -> bool:
+        """Propagate cost metadata through nested change dictionaries."""
+        for key, change in changes.items():
+            value = self.__getattribute__(key)
+            if isinstance(value, (EmbeddedModelObject, ModelObject)) and isinstance(change.to_value, dict):
+                if value.changes_are_cost_related(change.to_value):
+                    return True
+
+        return False
 
     def include_for_live_patch(self, context: LivePatchContext) -> bool:
         """

--- a/otterdog/models/github_organization.py
+++ b/otterdog/models/github_organization.py
@@ -22,6 +22,7 @@ from jsonbender import F, Forall, OptionalS, S, bend  # type: ignore
 from otterdog import resources
 from otterdog.logging import get_logger
 from otterdog.models import (
+    EmbeddedModelObject,
     FailureType,
     LivePatchContext,
     LivePatchHandler,
@@ -40,7 +41,6 @@ from otterdog.models.organization_secret import OrganizationSecret
 from otterdog.models.organization_settings import OrganizationSettings
 from otterdog.models.organization_variable import OrganizationVariable
 from otterdog.models.organization_webhook import OrganizationWebhook
-from otterdog.models.organization_workflow_settings import OrganizationWorkflowSettings
 from otterdog.models.repo_ruleset import RepositoryRuleset
 from otterdog.models.repo_secret import RepositorySecret
 from otterdog.models.repo_variable import RepositoryVariable
@@ -48,7 +48,14 @@ from otterdog.models.repo_webhook import RepositoryWebhook
 from otterdog.models.repo_workflow_settings import RepositoryWorkflowSettings
 from otterdog.models.repository import Repository
 from otterdog.models.team import Team
-from otterdog.utils import IndentingPrinter, associate_by_key, debug_times, is_set_and_present, jsonnet_evaluate_file
+from otterdog.utils import (
+    IndentingPrinter,
+    associate_by_key,
+    debug_times,
+    is_set_and_present,
+    is_set_and_valid,
+    jsonnet_evaluate_file,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Iterator
@@ -60,6 +67,18 @@ if TYPE_CHECKING:
 _ORG_SCHEMA = json.loads(files(resources).joinpath("schemas/organization.json").read_text())
 
 _logger = get_logger(__name__)
+
+
+def _configured_keys(model_object: EmbeddedModelObject) -> set[str]:
+    """
+    Returns the field names of an embedded model object that have a real, non-null value.
+
+    Unlike ``keys()``, this also excludes fields that are set to ``None`` because the jsonnet
+    default template declares them as ``null`` (jsonnet object inheritance means every derived
+    object ends up with that key present, even when not explicitly configured).
+    """
+    keys = model_object.keys()
+    return {k for k in keys if is_set_and_valid(model_object.__getattribute__(k))}
 
 
 @dataclasses.dataclass
@@ -529,6 +548,7 @@ class GitHubOrganization:
         concurrency: int | None = None,
         repo_filter: str | None = None,
         exclude_teams: Pattern | None = None,
+        expected_org: GitHubOrganization | None = None,
     ) -> GitHubOrganization:
         import asyncer
 
@@ -543,18 +563,24 @@ class GitHubOrganization:
             #        for now this is the same for organization settings, but there might be cases where it is different.
             default_settings = jsonnet_config.default_org_config["settings"]
             included_keys = set(default_settings.keys())
+            workflow_included_keys: set[str] | None
+            if expected_org is None:
+                # no expected config to compare against (e.g. import): fetch everything
+                workflow_included_keys = None
+            else:
+                default_workflows = default_settings.get("workflows") or {}
+                workflow_included_keys = {k for k, v in default_workflows.items() if v is not None}
+                workflow_included_keys.update(_configured_keys(expected_org.settings.workflows))
             github_settings = await provider.get_org_settings(github_id, included_keys, no_web_ui)
 
-            if "workflows" in included_keys:
-                github_settings["workflows"] = await provider.get_org_workflow_settings(github_id)
+            # for import (no expected config) always fetch workflow settings, even if the
+            # default template doesn't define a "workflows" section
+            if "workflows" in included_keys or expected_org is None:
+                github_settings["workflows"] = await provider.get_org_workflow_settings(
+                    github_id, included_keys=workflow_included_keys
+                )
 
             settings = OrganizationSettings.from_provider_data(github_id, github_settings)
-
-            if "workflows" in included_keys:
-                github_org_workflow_data = await provider.get_org_workflow_settings(github_id)
-                settings.workflows = OrganizationWorkflowSettings.from_provider_data(
-                    github_id, github_org_workflow_data
-                )
 
             if "custom_properties" in included_keys:
                 github_custom_properties = await provider.get_org_custom_properties(github_id)
@@ -662,6 +688,7 @@ class GitHubOrganization:
                     app_installations,
                     concurrency,
                     repo_filter,
+                    expected_org,
                 ):
                     org.add_repository(repo)
             else:
@@ -687,6 +714,7 @@ async def _process_single_repo(
     teams: dict[str, Any],
     repo_permissions: dict[str, list[dict[str, Any]]] | None,
     app_installations: dict[str, str],
+    expected_org: GitHubOrganization | None = None,
 ) -> tuple[str, Repository]:
     rest_api = gh_client.rest_api
 
@@ -695,7 +723,19 @@ async def _process_single_repo(
     repo = Repository.from_provider_data(github_id, github_repo_data)
 
     is_private = github_repo_data.get("private", False)
-    github_repo_workflow_data = await rest_api.repo.get_workflow_settings(github_id, repo_name, is_private=is_private)
+    expected_repo = expected_org.get_repository(repo_name) if expected_org is not None else None
+    workflow_included_keys: set[str] | None
+    if expected_org is None:
+        # no expected config to compare against (e.g. import): fetch everything
+        workflow_included_keys = None
+    else:
+        default_repo_workflows = jsonnet_config.default_repo_config.get("workflows") or {}
+        workflow_included_keys = {k for k, v in default_repo_workflows.items() if v is not None}
+        if expected_repo is not None:
+            workflow_included_keys.update(_configured_keys(expected_repo.workflows))
+    github_repo_workflow_data = await rest_api.repo.get_workflow_settings(
+        github_id, repo_name, is_private=is_private, included_keys=workflow_included_keys
+    )
     repo.workflows = RepositoryWorkflowSettings.from_provider_data(github_id, github_repo_workflow_data)
     if repo_permissions is not None:
         repo_permission = repo_permissions.get(repo_name, [])
@@ -827,6 +867,7 @@ async def _load_repos_from_provider(
     app_installations: dict[str, str],
     concurrency: int | None = None,
     repo_filter: str | None = None,
+    expected_org: GitHubOrganization | None = None,
 ) -> AsyncIterator[Repository]:
     import fnmatch
 
@@ -856,6 +897,7 @@ async def _load_repos_from_provider(
                 teams,
                 repo_permissions,
                 app_installations,
+                expected_org,
             )
 
     if concurrency is not None:

--- a/otterdog/models/ruleset.py
+++ b/otterdog/models/ruleset.py
@@ -501,7 +501,7 @@ class Ruleset(ModelObject, abc.ABC):
             }
         )
 
-        rules = data.get("rules", [])
+        rules = data.get("rules") or []
 
         def check_simple_rule(prop_key: str, rule_type: str, value_if_rule_is_present: bool) -> None:
             if any((_ := rule) for rule in rules if rule["type"] == rule_type):
@@ -562,14 +562,14 @@ class Ruleset(ModelObject, abc.ABC):
 
         # required pull request
         if any((found := rule) for rule in rules if rule["type"] == "pull_request"):
-            parameters = found.get("parameters", {})
+            parameters = found.get("parameters") or {}
             mapping["required_pull_request"] = K(PullRequestSettings.from_provider_data(org_id, parameters))
         else:
             mapping["required_pull_request"] = K(None)
 
         # required status checks
         if any((found := rule) for rule in rules if rule["type"] == "required_status_checks"):
-            parameters = found.get("parameters", {})
+            parameters = found.get("parameters") or {}
             mapping["required_status_checks"] = K(StatusCheckSettings.from_provider_data(org_id, parameters))
         else:
             mapping["required_status_checks"] = K(None)
@@ -577,7 +577,7 @@ class Ruleset(ModelObject, abc.ABC):
         # required deployments
         if any((found := rule) for rule in rules if rule["type"] == "required_deployments"):
             mapping["requires_deployments"] = K(True)
-            deployment_environments = found.get("parameters", {}).get("required_deployment_environments", [])
+            deployment_environments = (found.get("parameters") or {}).get("required_deployment_environments", [])
             mapping["required_deployment_environments"] = K(deployment_environments)
         else:
             mapping["requires_deployments"] = K(False)
@@ -585,7 +585,7 @@ class Ruleset(ModelObject, abc.ABC):
 
         # required merge queue
         if any((found := rule) for rule in rules if rule["type"] == "merge_queue"):
-            merge_queue_parameters = found.get("parameters", {})
+            merge_queue_parameters = found.get("parameters") or {}
             mapping["required_merge_queue"] = K(MergeQueueSettings.from_provider_data(org_id, merge_queue_parameters))
         else:
             mapping["required_merge_queue"] = K(None)
@@ -779,7 +779,7 @@ class Ruleset(ModelObject, abc.ABC):
             default_pull_request_config = cast("Ruleset", default_object).required_pull_request
             if default_pull_request_config is None:
                 default_pull_request_config = PullRequestSettings.from_model_data(
-                    jsonnet_config.default_pull_request_config
+                    jsonnet_config.default_pull_request_config or {}
                 )
                 embedded_extend = False
             else:
@@ -801,7 +801,7 @@ class Ruleset(ModelObject, abc.ABC):
             default_merge_queue_config = cast("Ruleset", default_object).required_merge_queue
             if default_merge_queue_config is None:
                 default_merge_queue_config = MergeQueueSettings.from_model_data(
-                    jsonnet_config.default_merge_queue_config
+                    jsonnet_config.default_merge_queue_config or {}
                 )
                 embedded_extend = False
             else:
@@ -823,7 +823,7 @@ class Ruleset(ModelObject, abc.ABC):
             default_status_check_config = cast("Ruleset", default_object).required_status_checks
             if default_status_check_config is None:
                 default_status_check_config = StatusCheckSettings.from_model_data(
-                    jsonnet_config.default_status_checks_config
+                    jsonnet_config.default_status_checks_config or {}
                 )
                 embedded_extend = False
             else:

--- a/otterdog/models/workflow_settings.py
+++ b/otterdog/models/workflow_settings.py
@@ -17,6 +17,7 @@ from jsonbender import OptionalS, S  # type: ignore
 from otterdog.models import EmbeddedModelObject, FailureType, PatchContext, ValidationContext
 from otterdog.utils import (
     UNSET,
+    Change,
     IndentingPrinter,
     is_set_and_valid,
     write_patch_object_as_json,
@@ -56,6 +57,15 @@ class WorkflowSettings(EmbeddedModelObject, abc.ABC):
     in https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28
     """
 
+    max_cache_size_gb: int
+    """
+    ``max_cache_size_gb`` controls the maximum total GitHub Actions cache size
+    for the relevant repository or organization.
+
+    Cache-size changes are marked as cost-related so pull-request validation can
+    require designated review and prevent automatic merging.
+    """
+
     _selected_action_properties: ClassVar[list[str]] = [
         "allow_github_owned_actions",
         "allow_verified_creator_actions",
@@ -67,6 +77,18 @@ class WorkflowSettings(EmbeddedModelObject, abc.ABC):
         "selected": 2,
         "local_only": 3,
     }
+
+    # Keep billing-affecting settings centralized so both full-object and
+    # change-level cost checks use the same definition.
+    _cost_related_properties: ClassVar[set[str]] = {"max_cache_size_gb"}
+
+    def is_cost_related(self) -> bool:
+        """Return whether this settings object contains a cost-affecting value."""
+        return any(is_set_and_valid(self.__getattribute__(key)) for key in self._cost_related_properties)
+
+    def changes_are_cost_related(self, changes: dict[str, Change]) -> bool:
+        """Return whether the supplied settings changes can affect costs."""
+        return any(key in changes for key in self._cost_related_properties)
 
     @classmethod
     def get_allowed_actions_level(cls, allowed_actions: str) -> int:

--- a/otterdog/operations/__init__.py
+++ b/otterdog/operations/__init__.py
@@ -346,7 +346,6 @@ class Operation(ABC):
                     else:
                         self.printer.println(f"[green]+ [/]{k.ljust(max_key_length, ' ')} = {self._get_value(v)}")
                 elif v is None:
-                    self.printer.println(f"[red]- [/]{k.ljust(max_key_length, ' ')} = {self._get_value(c_v)}")
                     self._print_modified_internal(k, max_key_length, c_v, v, "[green]+ [/]", "green", forced_update)
 
                 else:

--- a/otterdog/operations/diff_operation.py
+++ b/otterdog/operations/diff_operation.py
@@ -170,7 +170,7 @@ class DiffOperation(Operation):
         validation_status = await self.validate(expected_org, jsonnet_config)
         if self.handle_validation_status(validation_status):
             try:
-                current_org = await self.load_current_org(org_config.name, github_id, jsonnet_config)
+                current_org = await self.load_current_org(org_config.name, github_id, jsonnet_config, expected_org)
             except RuntimeError as e:
                 self.printer.print_error(f"failed to load current configuration\n{e!s}")
                 return 1
@@ -246,7 +246,11 @@ class DiffOperation(Operation):
         return True
 
     async def load_current_org(
-        self, project_name: str, github_id: str, jsonnet_config: JsonnetConfig
+        self,
+        project_name: str,
+        github_id: str,
+        jsonnet_config: JsonnetConfig,
+        expected_org: GitHubOrganization | None = None,
     ) -> GitHubOrganization:
         return await GitHubOrganization.load_from_provider(
             project_name,
@@ -257,6 +261,7 @@ class DiffOperation(Operation):
             self.concurrency,
             self.repo_filter,
             exclude_teams=self.config.exclude_teams_pattern,
+            expected_org=expected_org,
         )
 
     def preprocess_orgs(

--- a/otterdog/operations/local_apply.py
+++ b/otterdog/operations/local_apply.py
@@ -71,7 +71,11 @@ class LocalApplyOperation(ApplyOperation):
         return True
 
     async def load_current_org(
-        self, project_name: str, github_id: str, jsonnet_config: JsonnetConfig
+        self,
+        project_name: str,
+        github_id: str,
+        jsonnet_config: JsonnetConfig,
+        expected_org: GitHubOrganization | None = None,
     ) -> GitHubOrganization:
         other_org_file_name = jsonnet_config.org_config_file + self.suffix
 

--- a/otterdog/operations/local_plan.py
+++ b/otterdog/operations/local_plan.py
@@ -66,7 +66,11 @@ class LocalPlanOperation(PlanOperation):
         return GitHubProvider(self.get_credentials(org_config, only_token=True))
 
     async def load_current_org(
-        self, project_name: str, github_id: str, jsonnet_config: JsonnetConfig
+        self,
+        project_name: str,
+        github_id: str,
+        jsonnet_config: JsonnetConfig,
+        expected_org: GitHubOrganization | None = None,
     ) -> GitHubOrganization:
         other_org_file_name = jsonnet_config.org_config_file + self.suffix
 

--- a/otterdog/providers/github/__init__.py
+++ b/otterdog/providers/github/__init__.py
@@ -142,8 +142,8 @@ class GitHubProvider:
         if len(web_fields) > 0:
             await self.web_client.update_org_settings(org_id, web_fields)
 
-    async def get_org_workflow_settings(self, org_id: str) -> dict[str, Any]:
-        return await self.rest_api.org.get_workflow_settings(org_id)
+    async def get_org_workflow_settings(self, org_id: str, included_keys: set[str] | None = None) -> dict[str, Any]:
+        return await self.rest_api.org.get_workflow_settings(org_id, included_keys=included_keys)
 
     async def update_org_workflow_settings(self, org_id: str, workflow_settings: dict[str, Any]) -> None:
         await self.rest_api.org.update_workflow_settings(org_id, workflow_settings)
@@ -360,8 +360,12 @@ class GitHubProvider:
     async def delete_repo_environment(self, org_id: str, repo_name: str, env_name: str) -> None:
         await self.rest_api.repo.delete_environment(org_id, repo_name, env_name)
 
-    async def get_repo_workflow_settings(self, org_id: str, repo_name: str, is_private: bool = False) -> dict[str, Any]:
-        return await self.rest_api.repo.get_workflow_settings(org_id, repo_name, is_private=is_private)
+    async def get_repo_workflow_settings(
+        self, org_id: str, repo_name: str, is_private: bool = False, included_keys: set[str] | None = None
+    ) -> dict[str, Any]:
+        return await self.rest_api.repo.get_workflow_settings(
+            org_id, repo_name, is_private=is_private, included_keys=included_keys
+        )
 
     async def update_repo_workflow_settings(
         self, org_id: str, repo_name: str, workflow_settings: dict[str, Any], is_private: bool = False

--- a/otterdog/providers/github/rest/__init__.py
+++ b/otterdog/providers/github/rest/__init__.py
@@ -8,10 +8,12 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from otterdog.logging import get_logger
 from otterdog.providers.github.cache.file import file_cache
 
 from .requester import Requester
@@ -20,6 +22,8 @@ if TYPE_CHECKING:
     from otterdog.providers.github.auth import AuthStrategy
     from otterdog.providers.github.cache import CacheStrategy
     from otterdog.providers.github.stats import RequestStatistics
+
+_logger = get_logger(__name__)
 
 _DEFAULT_CACHE_STRATEGY = file_cache()
 
@@ -148,6 +152,33 @@ class RestClient:
     @property
     def requester(self) -> Requester:
         return self.__rest_api.requester
+
+    async def _get_optional_json(
+        self,
+        url_path: str,
+        *,
+        feature_description: str,
+        unavailable_statuses: tuple[int, ...] = (402, 403, 404),
+    ) -> dict[str, Any] | None:
+        """Fetch a GitHub endpoint that might not be available depending on the plan or add-ons.
+
+        Returns None (after warning once per endpoint) if the response status is one of
+        ``unavailable_statuses``, instead of raising.
+        """
+        status, body = await self.requester.request_raw("GET", url_path)
+
+        if status in unavailable_statuses:
+            _logger.warning(
+                "%s not available (status=%s), any configured setting will not be validated",
+                feature_description,
+                status,
+            )
+            return None
+
+        if status != 200:
+            raise RuntimeError(f"failed retrieving {feature_description}: {status}: {body}")
+
+        return json.loads(body)
 
 
 def encrypt_value(public_key: str, secret_value: str) -> str:

--- a/otterdog/providers/github/rest/org_client.py
+++ b/otterdog/providers/github/rest/org_client.py
@@ -516,6 +516,7 @@ class OrgClient(RestClient):
             workflow_settings.update(await self._get_default_workflow_permissions(org_id))
 
         workflow_settings.update(await self._get_fork_pr_approval_policy(org_id))
+        workflow_settings.update(await self._get_max_cache_size_gb(org_id))
 
         return workflow_settings
 
@@ -551,7 +552,37 @@ class OrgClient(RestClient):
         if "approval_policy" in data:
             await self._update_fork_pr_approval_policy(org_id, {"approval_policy": data["approval_policy"]})
 
+        if "max_cache_size_gb" in data:
+            await self._update_max_cache_size_gb(org_id, data["max_cache_size_gb"])
+
         _logger.debug("updated %d workflow setting(s)", len(data))
+
+    async def _get_max_cache_size_gb(self, org_id: str) -> dict[str, Any]:
+        _logger.debug("retrieving cache size for org '%s'", org_id)
+
+        response = await self.requester.request_json("GET", f"/organizations/{org_id}/actions/cache/storage-limit")
+        if "max_cache_size_gb" not in response:
+            # An incomplete success response must not become an absent setting:
+            # reconciliation would then skip drift detection for the configured limit.
+            raise RuntimeError(
+                f"GitHub response for organization cache size of '{org_id}' does not contain 'max_cache_size_gb'"
+            )
+
+        return {"max_cache_size_gb": response["max_cache_size_gb"]}
+
+    async def _update_max_cache_size_gb(self, org_id: str, max_cache_size_gb: int) -> None:
+        _logger.debug("updating cache size for org '%s'", org_id)
+
+        status, body = await self.requester.request_raw(
+            "PUT",
+            f"/organizations/{org_id}/actions/cache/storage-limit",
+            data=json.dumps({"max_cache_size_gb": max_cache_size_gb}),
+        )
+
+        if status != 204:
+            raise RuntimeError(f"failed to update cache size for org '{org_id}': {body}")
+
+        _logger.debug("updated cache size for org '%s'", org_id)
 
     async def _get_selected_repositories_for_workflow_settings(self, org_id: str) -> list[dict[str, Any]]:
         _logger.debug("retrieving selected repositories for org workflow settings of org '%s'", org_id)

--- a/otterdog/providers/github/rest/org_client.py
+++ b/otterdog/providers/github/rest/org_client.py
@@ -490,7 +490,7 @@ class OrgClient(RestClient):
         except GitHubException as ex:
             raise RuntimeError(f"failed getting app installations for org '{org_id}':\n{ex}") from ex
 
-    async def get_workflow_settings(self, org_id: str) -> dict[str, Any]:
+    async def get_workflow_settings(self, org_id: str, included_keys: set[str] | None = None) -> dict[str, Any]:
         _logger.debug("retrieving workflow settings for org '%s'", org_id)
 
         workflow_settings: dict[str, Any] = {}
@@ -516,7 +516,9 @@ class OrgClient(RestClient):
             workflow_settings.update(await self._get_default_workflow_permissions(org_id))
 
         workflow_settings.update(await self._get_fork_pr_approval_policy(org_id))
-        workflow_settings.update(await self._get_max_cache_size_gb(org_id))
+
+        if included_keys is None or "max_cache_size_gb" in included_keys:
+            workflow_settings.update(await self._get_max_cache_size_gb(org_id))
 
         return workflow_settings
 
@@ -560,7 +562,13 @@ class OrgClient(RestClient):
     async def _get_max_cache_size_gb(self, org_id: str) -> dict[str, Any]:
         _logger.debug("retrieving cache size for org '%s'", org_id)
 
-        response = await self.requester.request_json("GET", f"/organizations/{org_id}/actions/cache/storage-limit")
+        response = await self._get_optional_json(
+            f"/orgs/{org_id}/actions/cache/storage-limit",
+            feature_description=f"cache size for org '{org_id}'",
+        )
+        if response is None:
+            return {}
+
         if "max_cache_size_gb" not in response:
             # An incomplete success response must not become an absent setting:
             # reconciliation would then skip drift detection for the configured limit.
@@ -575,7 +583,7 @@ class OrgClient(RestClient):
 
         status, body = await self.requester.request_raw(
             "PUT",
-            f"/organizations/{org_id}/actions/cache/storage-limit",
+            f"/orgs/{org_id}/actions/cache/storage-limit",
             data=json.dumps({"max_cache_size_gb": max_cache_size_gb}),
         )
 

--- a/otterdog/providers/github/rest/repo_client.py
+++ b/otterdog/providers/github/rest/repo_client.py
@@ -1156,6 +1156,8 @@ class RepoClient(RestClient):
         if not is_private:
             workflow_settings.update(await self._get_fork_pr_approval_policy(org_id, repo_name))
 
+        workflow_settings.update(await self._get_max_cache_size_gb(org_id, repo_name))
+
         return workflow_settings
 
     async def update_workflow_settings(
@@ -1193,7 +1195,38 @@ class RepoClient(RestClient):
         if not is_private and "approval_policy" in data:
             await self._update_fork_pr_approval_policy(org_id, repo_name, {"approval_policy": data["approval_policy"]})
 
+        if "max_cache_size_gb" in data:
+            await self._update_max_cache_size_gb(org_id, repo_name, data["max_cache_size_gb"])
+
         _logger.debug("updated %d workflow setting(s)", len(data))
+
+    async def _get_max_cache_size_gb(self, org_id: str, repo_name: str) -> dict[str, Any]:
+        _logger.debug("retrieving cache size for repo '%s/%s'", org_id, repo_name)
+
+        response = await self.requester.request_json("GET", f"/repos/{org_id}/{repo_name}/actions/cache/storage-limit")
+        if "max_cache_size_gb" not in response:
+            # An incomplete success response must not become an absent setting:
+            # reconciliation would then skip drift detection for the configured limit.
+            raise RuntimeError(
+                f"GitHub response for repository cache size of '{org_id}/{repo_name}' "
+                "does not contain 'max_cache_size_gb'"
+            )
+
+        return {"max_cache_size_gb": response["max_cache_size_gb"]}
+
+    async def _update_max_cache_size_gb(self, org_id: str, repo_name: str, max_cache_size_gb: int) -> None:
+        _logger.debug("updating cache size for repo '%s/%s'", org_id, repo_name)
+
+        status, body = await self.requester.request_raw(
+            "PUT",
+            f"/repos/{org_id}/{repo_name}/actions/cache/storage-limit",
+            data=json.dumps({"max_cache_size_gb": max_cache_size_gb}),
+        )
+
+        if status != 204:
+            raise RuntimeError(f"failed to update cache size for repo '{org_id}/{repo_name}': {body}")
+
+        _logger.debug("updated cache size for repo '%s/%s'", org_id, repo_name)
 
     async def _get_selected_actions_for_workflow_settings(self, org_id: str, repo_name: str) -> dict[str, Any]:
         _logger.debug("retrieving allowed actions for repo '%s/%s'", org_id, repo_name)

--- a/otterdog/providers/github/rest/repo_client.py
+++ b/otterdog/providers/github/rest/repo_client.py
@@ -1135,7 +1135,9 @@ class RepoClient(RestClient):
 
         _logger.debug("removed repo variable '%s'", variable_name)
 
-    async def get_workflow_settings(self, org_id: str, repo_name: str, is_private: bool = False) -> dict[str, Any]:
+    async def get_workflow_settings(
+        self, org_id: str, repo_name: str, is_private: bool = False, included_keys: set[str] | None = None
+    ) -> dict[str, Any]:
         _logger.debug("retrieving workflow settings for repo '%s/%s'", org_id, repo_name)
 
         workflow_settings: dict[str, Any] = {}
@@ -1156,7 +1158,8 @@ class RepoClient(RestClient):
         if not is_private:
             workflow_settings.update(await self._get_fork_pr_approval_policy(org_id, repo_name))
 
-        workflow_settings.update(await self._get_max_cache_size_gb(org_id, repo_name))
+        if included_keys is None or "max_cache_size_gb" in included_keys:
+            workflow_settings.update(await self._get_max_cache_size_gb(org_id, repo_name))
 
         return workflow_settings
 
@@ -1203,7 +1206,13 @@ class RepoClient(RestClient):
     async def _get_max_cache_size_gb(self, org_id: str, repo_name: str) -> dict[str, Any]:
         _logger.debug("retrieving cache size for repo '%s/%s'", org_id, repo_name)
 
-        response = await self.requester.request_json("GET", f"/repos/{org_id}/{repo_name}/actions/cache/storage-limit")
+        response = await self._get_optional_json(
+            f"/repos/{org_id}/{repo_name}/actions/cache/storage-limit",
+            feature_description=f"cache size for repo '{org_id}/{repo_name}'",
+        )
+        if response is None:
+            return {}
+
         if "max_cache_size_gb" not in response:
             # An incomplete success response must not become an absent setting:
             # reconciliation would then skip drift detection for the configured limit.

--- a/otterdog/resources/schemas/workflow-settings.json
+++ b/otterdog/resources/schemas/workflow-settings.json
@@ -12,6 +12,7 @@
     },
     "default_workflow_permissions": { "type": "string" },
     "actions_can_approve_pull_request_reviews": { "type": "boolean" },
-    "fork_pr_approval_policy": { "type": "string" }
+    "fork_pr_approval_policy": { "type": "string" },
+    "max_cache_size_gb": { "type": "integer" }
   }
 }

--- a/otterdog/resources/schemas/workflow-settings.json
+++ b/otterdog/resources/schemas/workflow-settings.json
@@ -13,6 +13,6 @@
     "default_workflow_permissions": { "type": "string" },
     "actions_can_approve_pull_request_reviews": { "type": "boolean" },
     "fork_pr_approval_policy": { "type": "string" },
-    "max_cache_size_gb": { "type": "integer" }
+    "max_cache_size_gb": { "type": ["integer", "null"] }
   }
 }

--- a/otterdog/webapp/tasks/validate_pull_request.py
+++ b/otterdog/webapp/tasks/validate_pull_request.py
@@ -37,11 +37,18 @@ if TYPE_CHECKING:
 
 @dataclass
 class ValidationResult:
+    """Validation output and safety gates for applying a pull request.
+
+    Cost-related changes are tracked separately because they require designated
+    review and must not be auto-merged, even when they need no manual UI work.
+    """
+
     plan_output: str = ""
     validation_success: bool = False
     touches_non_configuration: bool = False
     requires_secrets: bool | None = None
     requires_web_ui: bool | None = None
+    cost_related: bool | None = None
     includes_deletions: bool | None = None
 
 
@@ -156,6 +163,7 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
                 ):
                     validation_result.requires_secrets = any(x.requires_secrets() for x in patches)
                     validation_result.requires_web_ui = any(x.requires_web_ui() for x in patches)
+                    validation_result.cost_related = any(x.is_cost_related() for x in patches)
 
                     validation_result.includes_deletions = any(x.patch_type == LivePatchType.REMOVE for x in patches)
 
@@ -191,6 +199,9 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
                 warnings.append(
                     "some of requested changes require accessing the Web UI, need to apply these changes manually"
                 )
+            if validation_result.cost_related:
+                # Cost changes need review even when the change itself is API-applicable.
+                warnings.append("some of requested changes may incur costs, need review by the designated team")
 
             comment = await render_template(
                 "comment/validation_comment.txt",
@@ -263,10 +274,12 @@ class ValidatePullRequestTask(InstallationBasedTask, Task[ValidationResult]):
             self.repo_name,
             self._pull_request,
             valid=validation_result.validation_success,
-            requires_manual_apply=validation_result.requires_secrets or validation_result.requires_web_ui,
+            requires_manual_apply=(validation_result.requires_secrets or validation_result.requires_web_ui),
             supports_auto_merge=not (
                 validation_result.requires_secrets
                 or validation_result.requires_web_ui
+                # Cost-affecting changes require explicit review before merging.
+                or validation_result.cost_related
                 or validation_result.includes_deletions
                 or validation_result.touches_non_configuration
             ),

--- a/tests/models/test_workflow_settings.py
+++ b/tests/models/test_workflow_settings.py
@@ -10,7 +10,7 @@ import pytest
 from pretend import stub
 
 from otterdog.models.workflow_settings import WorkflowSettings
-from otterdog.utils import UNSET
+from otterdog.utils import UNSET, Change
 
 
 # Subclass to test abstract WorkflowSettings logic.
@@ -29,6 +29,7 @@ def workflow_settings():
         default_workflow_permissions="read",
         actions_can_approve_pull_request_reviews=True,
         fork_pr_approval_policy="first_time_contributors",
+        max_cache_size_gb=10,
     )
 
 
@@ -86,3 +87,7 @@ class TestWorkflowSettingsMapping:
         data = {}
         mapping = await TestWorkflowSettings.get_mapping_to_provider("test-id", data, provider)
         assert "approval_policy" not in mapping
+
+    def test_cache_size_changes_are_cost_related(self, workflow_settings):
+        assert workflow_settings.is_cost_related()
+        assert workflow_settings.changes_are_cost_related({"max_cache_size_gb": Change(10, 50)})

--- a/tests/providers/github/integration/test_workflow_settings.py
+++ b/tests/providers/github/integration/test_workflow_settings.py
@@ -1,0 +1,174 @@
+#  *******************************************************************************
+#  Copyright (c) 2026 Eclipse Foundation and others.
+#  This program and the accompanying materials are made available
+#  under the terms of the Eclipse Public License 2.0
+#  which is available at http://www.eclipse.org/legal/epl-v20.html
+#  SPDX-License-Identifier: EPL-2.0
+#  *******************************************************************************
+
+import pytest
+
+from otterdog.models.organization_workflow_settings import OrganizationWorkflowSettings
+from otterdog.models.repo_workflow_settings import RepositoryWorkflowSettings
+from otterdog.providers.github.exception import GitHubException
+
+from .conftest import GitHubProviderTestKit
+
+# Constants
+ORG_ID = "test-org"
+REPO_NAME = "test-repo"
+
+
+async def test_read_org_workflow_settings(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions",
+        response_json={"enabled_repositories": "none", "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions/fork-pr-contributor-approval",
+        response_json={"approval_policy": "first_time_contributors"},
+    )
+    github.http.expect(
+        "GET",
+        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        response_json={"max_cache_size_gb": 50},
+    )
+
+    provider_data = await github.provider.get_org_workflow_settings(ORG_ID)
+    settings = OrganizationWorkflowSettings.from_provider_data(ORG_ID, provider_data)
+
+    assert settings.max_cache_size_gb == 50
+
+
+@pytest.mark.parametrize("response_status", [403, 500])
+async def test_read_org_workflow_settings_propagates_cache_limit_errors(
+    github: GitHubProviderTestKit, response_status: int
+):
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions",
+        response_json={"enabled_repositories": "none", "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions/fork-pr-contributor-approval",
+        response_json={"approval_policy": "first_time_contributors"},
+    )
+    github.http.expect(
+        "GET",
+        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        response_status=response_status,
+        response_text="cache limit unavailable",
+    )
+
+    with pytest.raises(GitHubException):
+        await github.provider.get_org_workflow_settings(ORG_ID)
+
+
+async def test_read_org_workflow_settings_rejects_incomplete_cache_limit_response(
+    github: GitHubProviderTestKit,
+):
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions",
+        response_json={"enabled_repositories": "none", "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions/fork-pr-contributor-approval",
+        response_json={"approval_policy": "first_time_contributors"},
+    )
+    github.http.expect(
+        "GET",
+        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        response_json={},
+    )
+
+    with pytest.raises(RuntimeError, match="max_cache_size_gb"):
+        await github.provider.get_org_workflow_settings(ORG_ID)
+
+
+async def test_update_org_workflow_settings(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        request_json={"max_cache_size_gb": 50},
+        response_status=204,
+    )
+
+    provider_data = await OrganizationWorkflowSettings.dict_to_provider_data(
+        ORG_ID, {"max_cache_size_gb": 50}, github.provider
+    )
+    await github.provider.update_org_workflow_settings(ORG_ID, provider_data)
+
+
+async def test_read_repo_workflow_settings(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/permissions",
+        response_json={"enabled": False, "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        response_json={"max_cache_size_gb": 50},
+    )
+
+    provider_data = await github.provider.get_repo_workflow_settings(ORG_ID, REPO_NAME, is_private=True)
+    settings = RepositoryWorkflowSettings.from_provider_data(ORG_ID, provider_data)
+
+    assert settings.max_cache_size_gb == 50
+
+
+@pytest.mark.parametrize("response_status", [403, 500])
+async def test_read_repo_workflow_settings_propagates_cache_limit_errors(
+    github: GitHubProviderTestKit, response_status: int
+):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/permissions",
+        response_json={"enabled": False, "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        response_status=response_status,
+        response_text="cache limit unavailable",
+    )
+
+    with pytest.raises(GitHubException):
+        await github.provider.get_repo_workflow_settings(ORG_ID, REPO_NAME, is_private=True)
+
+
+async def test_read_repo_workflow_settings_rejects_incomplete_cache_limit_response(
+    github: GitHubProviderTestKit,
+):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/permissions",
+        response_json={"enabled": False, "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        response_json={},
+    )
+
+    with pytest.raises(RuntimeError, match="max_cache_size_gb"):
+        await github.provider.get_repo_workflow_settings(ORG_ID, REPO_NAME, is_private=True)
+
+
+async def test_update_repo_workflow_settings(github: GitHubProviderTestKit):
+    github.http.expect(
+        "PUT",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        request_json={"max_cache_size_gb": 50},
+        response_status=204,
+    )
+
+    provider_data = await RepositoryWorkflowSettings.dict_to_provider_data(
+        ORG_ID, {"max_cache_size_gb": 50}, github.provider
+    )
+    await github.provider.update_repo_workflow_settings(ORG_ID, REPO_NAME, provider_data, is_private=True)

--- a/tests/providers/github/integration/test_workflow_settings.py
+++ b/tests/providers/github/integration/test_workflow_settings.py
@@ -10,7 +10,7 @@ import pytest
 
 from otterdog.models.organization_workflow_settings import OrganizationWorkflowSettings
 from otterdog.models.repo_workflow_settings import RepositoryWorkflowSettings
-from otterdog.providers.github.exception import GitHubException
+from otterdog.utils import is_set_and_present
 
 from .conftest import GitHubProviderTestKit
 
@@ -32,7 +32,7 @@ async def test_read_org_workflow_settings(github: GitHubProviderTestKit):
     )
     github.http.expect(
         "GET",
-        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        f"/orgs/{ORG_ID}/actions/cache/storage-limit",
         response_json={"max_cache_size_gb": 50},
     )
 
@@ -42,10 +42,7 @@ async def test_read_org_workflow_settings(github: GitHubProviderTestKit):
     assert settings.max_cache_size_gb == 50
 
 
-@pytest.mark.parametrize("response_status", [403, 500])
-async def test_read_org_workflow_settings_propagates_cache_limit_errors(
-    github: GitHubProviderTestKit, response_status: int
-):
+async def test_read_org_workflow_settings_ignores_unavailable_cache_limit(github: GitHubProviderTestKit):
     github.http.expect(
         "GET",
         f"/orgs/{ORG_ID}/actions/permissions",
@@ -58,12 +55,36 @@ async def test_read_org_workflow_settings_propagates_cache_limit_errors(
     )
     github.http.expect(
         "GET",
-        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
-        response_status=response_status,
+        f"/orgs/{ORG_ID}/actions/cache/storage-limit",
+        response_status=403,
         response_text="cache limit unavailable",
     )
 
-    with pytest.raises(GitHubException):
+    provider_data = await github.provider.get_org_workflow_settings(ORG_ID)
+    settings = OrganizationWorkflowSettings.from_provider_data(ORG_ID, provider_data)
+
+    assert not is_set_and_present(settings.max_cache_size_gb)
+
+
+async def test_read_org_workflow_settings_propagates_cache_limit_errors(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions",
+        response_json={"enabled_repositories": "none", "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/permissions/fork-pr-contributor-approval",
+        response_json={"approval_policy": "first_time_contributors"},
+    )
+    github.http.expect(
+        "GET",
+        f"/orgs/{ORG_ID}/actions/cache/storage-limit",
+        response_status=500,
+        response_text="cache limit unavailable",
+    )
+
+    with pytest.raises(RuntimeError):
         await github.provider.get_org_workflow_settings(ORG_ID)
 
 
@@ -82,7 +103,7 @@ async def test_read_org_workflow_settings_rejects_incomplete_cache_limit_respons
     )
     github.http.expect(
         "GET",
-        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        f"/orgs/{ORG_ID}/actions/cache/storage-limit",
         response_json={},
     )
 
@@ -93,7 +114,7 @@ async def test_read_org_workflow_settings_rejects_incomplete_cache_limit_respons
 async def test_update_org_workflow_settings(github: GitHubProviderTestKit):
     github.http.expect(
         "PUT",
-        f"/organizations/{ORG_ID}/actions/cache/storage-limit",
+        f"/orgs/{ORG_ID}/actions/cache/storage-limit",
         request_json={"max_cache_size_gb": 50},
         response_status=204,
     )
@@ -122,10 +143,7 @@ async def test_read_repo_workflow_settings(github: GitHubProviderTestKit):
     assert settings.max_cache_size_gb == 50
 
 
-@pytest.mark.parametrize("response_status", [403, 500])
-async def test_read_repo_workflow_settings_propagates_cache_limit_errors(
-    github: GitHubProviderTestKit, response_status: int
-):
+async def test_read_repo_workflow_settings_ignores_unavailable_cache_limit(github: GitHubProviderTestKit):
     github.http.expect(
         "GET",
         f"/repos/{ORG_ID}/{REPO_NAME}/actions/permissions",
@@ -134,11 +152,30 @@ async def test_read_repo_workflow_settings_propagates_cache_limit_errors(
     github.http.expect(
         "GET",
         f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
-        response_status=response_status,
+        response_status=403,
         response_text="cache limit unavailable",
     )
 
-    with pytest.raises(GitHubException):
+    provider_data = await github.provider.get_repo_workflow_settings(ORG_ID, REPO_NAME, is_private=True)
+    settings = RepositoryWorkflowSettings.from_provider_data(ORG_ID, provider_data)
+
+    assert not is_set_and_present(settings.max_cache_size_gb)
+
+
+async def test_read_repo_workflow_settings_propagates_cache_limit_errors(github: GitHubProviderTestKit):
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/permissions",
+        response_json={"enabled": False, "allowed_actions": "none"},
+    )
+    github.http.expect(
+        "GET",
+        f"/repos/{ORG_ID}/{REPO_NAME}/actions/cache/storage-limit",
+        response_status=500,
+        response_text="cache limit unavailable",
+    )
+
+    with pytest.raises(RuntimeError):
         await github.provider.get_repo_workflow_settings(ORG_ID, REPO_NAME, is_private=True)
 
 

--- a/tests/providers/github/rest/test_org_client.py
+++ b/tests/providers/github/rest/test_org_client.py
@@ -11,7 +11,8 @@ import json
 import pretend
 import pytest
 
-from otterdog.providers.github.rest.org_client import GitHubException, OrgClient
+from otterdog.providers.github.exception import GitHubException
+from otterdog.providers.github.rest.org_client import OrgClient
 
 
 class TestOrgClientForkPrApprovalPolicy:
@@ -113,6 +114,11 @@ class TestOrgClientForkPrApprovalPolicy:
         mock_restapi = pretend.stub(requester=mock_requester)
         org_client = OrgClient(mock_restapi)
         org_client._get_fork_pr_approval_policy = mock_get
+
+        async def mock_cache_size(org):
+            return {"max_cache_size_gb": 10}
+
+        org_client._get_max_cache_size_gb = mock_cache_size
 
         result = await org_client.get_workflow_settings("org")
 

--- a/tests/providers/github/rest/test_org_client.py
+++ b/tests/providers/github/rest/test_org_client.py
@@ -15,6 +15,54 @@ from otterdog.providers.github.exception import GitHubException
 from otterdog.providers.github.rest.org_client import OrgClient
 
 
+class TestRestClientOptionalJson:
+    async def test_get_optional_json_returns_response(self):
+        expected_response = {"max_cache_size_gb": 50}
+
+        async def mock_request(method, url):
+            assert method == "GET"
+            assert url == "/orgs/org/actions/cache/storage-limit"
+            return 200, json.dumps(expected_response)
+
+        mock_requester = pretend.stub(request_raw=mock_request)
+        org_client = OrgClient(pretend.stub(requester=mock_requester))
+
+        result = await org_client._get_optional_json(
+            "/orgs/org/actions/cache/storage-limit",
+            feature_description="cache size for org 'org'",
+        )
+
+        assert result == expected_response
+
+    @pytest.mark.parametrize("status", [402, 403, 404])
+    async def test_get_optional_json_returns_none_for_unavailable_endpoint(self, status):
+        async def mock_request(method, url):
+            return status, "feature unavailable"
+
+        mock_requester = pretend.stub(request_raw=mock_request)
+        org_client = OrgClient(pretend.stub(requester=mock_requester))
+
+        result = await org_client._get_optional_json(
+            "/orgs/org/actions/cache/storage-limit",
+            feature_description="cache size for org 'org'",
+        )
+
+        assert result is None
+
+    async def test_get_optional_json_raises_for_unexpected_status(self):
+        async def mock_request(method, url):
+            return 500, "internal server error"
+
+        mock_requester = pretend.stub(request_raw=mock_request)
+        org_client = OrgClient(pretend.stub(requester=mock_requester))
+
+        with pytest.raises(RuntimeError, match="cache size for org 'org': 500"):
+            await org_client._get_optional_json(
+                "/orgs/org/actions/cache/storage-limit",
+                feature_description="cache size for org 'org'",
+            )
+
+
 class TestOrgClientForkPrApprovalPolicy:
     async def test_get_fork_pr_approval_policy_success(self):
         expected_policy = {"approval_policy": "first_time_contributors"}

--- a/tests/providers/github/rest/test_repo_client.py
+++ b/tests/providers/github/rest/test_repo_client.py
@@ -3,7 +3,8 @@ import json
 import pretend
 import pytest
 
-from otterdog.providers.github.rest.repo_client import GitHubException, RepoClient
+from otterdog.providers.github.exception import GitHubException
+from otterdog.providers.github.rest.repo_client import RepoClient
 
 
 class TestRepoClientCodeScanningConfig:
@@ -244,6 +245,11 @@ class TestRepoClientForkPrApprovalPolicy:
         repo_client = RepoClient(mock_restapi)
         repo_client._get_fork_pr_approval_policy = mock_get
 
+        async def mock_cache_size(org, repo):
+            return {"max_cache_size_gb": 10}
+
+        repo_client._get_max_cache_size_gb = mock_cache_size
+
         result = await repo_client.get_workflow_settings("org", "repo")
 
         # Assert result includes the approval policy
@@ -263,6 +269,11 @@ class TestRepoClientForkPrApprovalPolicy:
         mock_restapi = pretend.stub(requester=mock_requester)
         repo_client = RepoClient(mock_restapi)
         repo_client._get_fork_pr_approval_policy = mock_get
+
+        async def mock_cache_size(org, repo):
+            return {"max_cache_size_gb": 10}
+
+        repo_client._get_max_cache_size_gb = mock_cache_size
 
         result = await repo_client.get_workflow_settings("org", "repo", is_private=True)
 

--- a/tests/schemas/test_workflow_settings_schema.py
+++ b/tests/schemas/test_workflow_settings_schema.py
@@ -83,6 +83,7 @@ class TestWorkflowSettingsSchemaComposition:
             "default_workflow_permissions": "read",
             "actions_can_approve_pull_request_reviews": True,
             "fork_pr_approval_policy": "first_time_contributors",
+            "max_cache_size_gb": 50,
         }
 
         validator.validate(data)
@@ -117,6 +118,7 @@ class TestWorkflowSettingsSchemaComposition:
             "default_workflow_permissions": "write",
             "actions_can_approve_pull_request_reviews": False,
             "fork_pr_approval_policy": "all_external_contributors",
+            "max_cache_size_gb": 50,
         }
 
         validator.validate(data)
@@ -136,6 +138,7 @@ class TestWorkflowSettingsSchemaComposition:
             "default_workflow_permissions": "read",
             "actions_can_approve_pull_request_reviews": False,
             "fork_pr_approval_policy": "first_time_contributors_new_to_github",
+            "max_cache_size_gb": 50,
         }
 
         validator.validate(data)
@@ -165,6 +168,7 @@ class TestWorkflowSettingsSchemaComposition:
             ("default_workflow_permissions", "write"),
             ("actions_can_approve_pull_request_reviews", True),
             ("fork_pr_approval_policy", "first_time_contributors"),
+            ("max_cache_size_gb", 50),
         ],
     )
     def test_org_workflow_inherits_individual_base_fields(
@@ -190,6 +194,7 @@ class TestWorkflowSettingsSchemaComposition:
             ("default_workflow_permissions", "read"),
             ("actions_can_approve_pull_request_reviews", False),
             ("fork_pr_approval_policy", "all_external_contributors"),
+            ("max_cache_size_gb", 50),
         ],
     )
     def test_repo_workflow_inherits_individual_base_fields(


### PR DESCRIPTION
Adds support for managing GitHub Actions max_cache_size_gb at organization and repository levels.

* Fetches and applies cache storage limits through GitHub REST endpoints.
* Imports cache limits into generated Jsonnet configuration.
* Skips cache-limit requests during plans when the setting is not configured.
* Handles unavailable endpoints (402, 403, 404) without failing the whole plan.
* Emits a warning only when a configured cache limit cannot be validated.
* Fixes organization workflow settings retrieval during import.
* Adds tests for cache-limit behavior and the generic optional JSON endpoint helper.

Related to https://github.com/eclipse-csi/otterdog/pull/737
