### PR TITLE
Dependabot support python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

Make Dependabot support python ecosystem and generate poetry.lock file.

For reference, the old Dependabot PRs required manual fixes: https://github.com/eclipse-csi/otterdog/pull/743

### Type of change

<!-- Check all that apply. -->

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior, config schema, or default template)
- [ ] 📝 Documentation only
- [ ] 🔧 Refactoring / internal change (no functional change)